### PR TITLE
feat: enable inverting archive behaviour

### DIFF
--- a/__tests__/main.js
+++ b/__tests__/main.js
@@ -4,199 +4,249 @@ const {
   createPostGraphileSchema,
   withPostGraphileContext,
 } = require("postgraphile");
+
+/*
+ * In this database we add four columns:
+ *
+ * - is_archived - boolean, true if hidden by default
+ * - archived_at - nullable timestamp, non-null if hidden by default
+ * - is_published - boolean, false if hidden by default
+ * - published_at - nullable timestamp, null if hidden by default
+ *
+ * In a normal database you'd only have one of these, we just add 4 so we can
+ * run the tests for each of these combinations.
+ */
+
 const SQL = `
 drop schema if exists omit_archived cascade;
 create schema omit_archived;
 create table omit_archived.parents (
   id int primary key,
   name text,
-  is_archived boolean not null default false
+  is_archived boolean not null default false,
+  archived_at timestamptz default null,
+  is_published boolean not null default true,
+  published_at timestamptz default now()
 );
 create table omit_archived.children (
   id int primary key,
   parent_id int not null references omit_archived.parents,
   name text,
-  is_archived boolean not null default false
+  is_archived boolean not null default false,
+  archived_at timestamptz default null,
+  is_published boolean not null default true,
+  published_at timestamptz default now()
 );
 create index on omit_archived.children(parent_id);
-insert into omit_archived.parents (id, name, is_archived) values (1, 'First', false), (2, 'Second', true);
-insert into omit_archived.children (id, parent_id, name, is_archived) values
-  (1001, 1, 'First child 1', false), (1002, 1, 'First child 2', true),
-  (2001, 2, 'Second child 1', false), (2002, 2, 'Second child 2', true);
+insert into omit_archived.parents (id, name, is_archived, archived_at, is_published, published_at)
+  values (1, 'First', false, null, true, now()), (2, 'Second', true, now(), false, null);
+insert into omit_archived.children (id, parent_id, name, is_archived, archived_at, is_published, published_at) values
+  (1001, 1, 'First child 1', false, null, true, now()),
+  (1002, 1, 'First child 2', true, now(), false, null),
+  (2001, 2, 'Second child 1', false, null, true, now()),
+  (2002, 2, 'Second child 2', true, now(), false, null);
 `;
 
 function iderize(...ids) {
-  return ids.map(id => ({ id }));
+  return ids.map((id) => ({ id }));
 }
 
 let pgPool;
-let schema;
-const options = {
-  appendPlugins: [require("..").default],
-  simpleCollections: "both",
-};
 beforeAll(() => {
   pgPool = new pg.Pool({
     connectionString: process.env.TEST_DATABASE_URL || "pggql_test",
   });
 });
 beforeAll(() => pgPool.query(SQL));
-beforeAll(async () => {
-  schema = await createPostGraphileSchema(pgPool, ["omit_archived"], options);
-});
 afterAll(() => pgPool.end());
 
-function check(query, expected) {
-  const rootValue = null;
-  const variables = {};
-  const operationName = null;
-  return () =>
-    withPostGraphileContext(
-      {
-        pgPool,
-        ...options,
-      },
-      async context => {
-        const result = await graphql(
-          schema,
-          query,
-          rootValue,
-          context,
-          variables,
-          operationName,
-        );
-        expect(result.errors).toBeFalsy();
-        expect(result.data).toEqual(expected);
-      },
-    );
-}
+describe.each([
+  ["default"],
+  ["is_archived", "archived", { pgArchivedColumnName: "is_archived" }],
+  ["archived_at", "archived", { pgArchivedColumnName: "archived_at" }],
+  [
+    "is_published",
+    "draft",
+    {
+      pgDraftColumnName: "is_published",
+      pgDraftColumnImpliesVisible: true,
+    },
+  ],
+  [
+    "published_at",
+    "draft",
+    {
+      pgDraftColumnName: "published_at",
+      pgDraftColumnImpliesVisible: true,
+    },
+  ],
+])("%s", (_columnName, keyword, graphileBuildOptions) => {
+  const Keyword = keyword
+    ? keyword[0].toUpperCase() + keyword.slice(1)
+    : `Archived`;
+  let schema;
+  const options = {
+    appendPlugins: [
+      keyword ? require("..").custom(keyword) : require("..").default,
+    ],
+    simpleCollections: "both",
+    graphileBuildOptions,
+  };
+  beforeAll(async () => {
+    schema = await createPostGraphileSchema(pgPool, ["omit_archived"], options);
+  });
 
-describe("connections", () => {
-  describe("parents", () => {
-    test(
-      "Omits archived parents by default",
-      check(
-        `{
+  function check(query, expected) {
+    const rootValue = null;
+    const variables = {};
+    const operationName = null;
+    return () =>
+      withPostGraphileContext(
+        {
+          pgPool,
+          ...options,
+        },
+        async (context) => {
+          const result = await graphql(
+            schema,
+            query,
+            rootValue,
+            context,
+            variables,
+            operationName,
+          );
+          expect(result.errors).toBeFalsy();
+          expect(result.data).toEqual(expected);
+        },
+      );
+  }
+
+  describe("connections", () => {
+    describe("parents", () => {
+      test(
+        "Omits archived parents by default",
+        check(
+          `{
           allParents {
             nodes {
               id
             }
           }
         }`,
-        { allParents: { nodes: iderize(1) } },
-      ),
-    );
+          { allParents: { nodes: iderize(1) } },
+        ),
+      );
 
-    test(
-      "Omits archived parents when NO",
-      check(
-        `{
-          allParents(includeArchived: NO) {
+      test(
+        "Omits archived parents when NO",
+        check(
+          `{
+          allParents(include${Keyword}: NO) {
             nodes {
               id
             }
           }
         }`,
-        { allParents: { nodes: iderize(1) } },
-      ),
-    );
+          { allParents: { nodes: iderize(1) } },
+        ),
+      );
 
-    test(
-      "Includes everything when YES",
-      check(
-        `{
-          allParents(includeArchived: YES) {
+      test(
+        "Includes everything when YES",
+        check(
+          `{
+          allParents(include${Keyword}: YES) {
             nodes {
               id
             }
           }
         }`,
-        { allParents: { nodes: iderize(1, 2) } },
-      ),
-    );
+          { allParents: { nodes: iderize(1, 2) } },
+        ),
+      );
 
-    test(
-      "Includes only archived when EXCLUSIVELY",
-      check(
-        `{
-          allParents(includeArchived: EXCLUSIVELY) {
+      test(
+        "Includes only archived when EXCLUSIVELY",
+        check(
+          `{
+          allParents(include${Keyword}: EXCLUSIVELY) {
             nodes {
               id
             }
           }
         }`,
-        { allParents: { nodes: iderize(2) } },
-      ),
-    );
-  });
+          { allParents: { nodes: iderize(2) } },
+        ),
+      );
+    });
 
-  describe("children", () => {
-    test(
-      "Omits archived children by default",
-      check(
-        `{
+    describe("children", () => {
+      test(
+        "Omits archived children by default",
+        check(
+          `{
           allChildren {
             nodes {
               id
             }
           }
         }`,
-        { allChildren: { nodes: iderize(1001, 2001) } },
-      ),
-    );
+          { allChildren: { nodes: iderize(1001, 2001) } },
+        ),
+      );
 
-    test(
-      "Omits archived children when NO",
-      check(
-        `{
-          allChildren(includeArchived: NO) {
+      test(
+        "Omits archived children when NO",
+        check(
+          `{
+          allChildren(include${Keyword}: NO) {
             nodes {
               id
             }
           }
         }`,
-        { allChildren: { nodes: iderize(1001, 2001) } },
-      ),
-    );
+          { allChildren: { nodes: iderize(1001, 2001) } },
+        ),
+      );
 
-    test(
-      "Includes everything when YES",
-      check(
-        `{
-          allChildren(includeArchived: YES) {
+      test(
+        "Includes everything when YES",
+        check(
+          `{
+          allChildren(include${Keyword}: YES) {
             nodes {
               id
             }
           }
         }`,
-        {
-          allChildren: {
-            nodes: iderize(1001, 1002, 2001, 2002),
+          {
+            allChildren: {
+              nodes: iderize(1001, 1002, 2001, 2002),
+            },
           },
-        },
-      ),
-    );
+        ),
+      );
 
-    test(
-      "Includes only archived when EXCLUSIVELY",
-      check(
-        `{
-          allChildren(includeArchived: EXCLUSIVELY) {
+      test(
+        "Includes only archived when EXCLUSIVELY",
+        check(
+          `{
+          allChildren(include${Keyword}: EXCLUSIVELY) {
             nodes {
               id
             }
           }
         }`,
-        { allChildren: { nodes: iderize(1002, 2002) } },
-      ),
-    );
-  });
+          { allChildren: { nodes: iderize(1002, 2002) } },
+        ),
+      );
+    });
 
-  describe("children of parents", () => {
-    test(
-      "Omits archived parents and children by default",
-      check(
-        `{
+    describe("children of parents", () => {
+      test(
+        "Omits archived parents and children by default",
+        check(
+          `{
           allParents {
             nodes {
               id
@@ -208,24 +258,24 @@ describe("connections", () => {
             }
           }
         }`,
-        {
-          allParents: {
-            nodes: [
-              {
-                id: 1,
-                childrenByParentId: { nodes: iderize(1001) },
-              },
-            ],
+          {
+            allParents: {
+              nodes: [
+                {
+                  id: 1,
+                  childrenByParentId: { nodes: iderize(1001) },
+                },
+              ],
+            },
           },
-        },
-      ),
-    );
+        ),
+      );
 
-    test(
-      "Omits archived parents and children when NO",
-      check(
-        `{
-          allParents(includeArchived: NO) {
+      test(
+        "Omits archived parents and children when NO",
+        check(
+          `{
+          allParents(include${Keyword}: NO) {
             nodes {
               id
               childrenByParentId {
@@ -236,24 +286,24 @@ describe("connections", () => {
             }
           }
         }`,
-        {
-          allParents: {
-            nodes: [
-              {
-                id: 1,
-                childrenByParentId: { nodes: iderize(1001) },
-              },
-            ],
+          {
+            allParents: {
+              nodes: [
+                {
+                  id: 1,
+                  childrenByParentId: { nodes: iderize(1001) },
+                },
+              ],
+            },
           },
-        },
-      ),
-    );
+        ),
+      );
 
-    test(
-      "Includes all parents, and treats children as INHERIT (all children of an archived parent, but only the unarchived children of an unarchived parent) when YES",
-      check(
-        `{
-          allParents(includeArchived: YES) {
+      test(
+        "Includes all parents, and treats children as INHERIT (all children of an archived parent, but only the unarchived children of an unarchived parent) when YES",
+        check(
+          `{
+          allParents(include${Keyword}: YES) {
             nodes {
               id
               childrenByParentId {
@@ -264,28 +314,28 @@ describe("connections", () => {
             }
           }
         }`,
-        {
-          allParents: {
-            nodes: [
-              {
-                id: 1,
-                childrenByParentId: { nodes: iderize(1001) },
-              },
-              {
-                id: 2,
-                childrenByParentId: { nodes: iderize(2001, 2002) },
-              },
-            ],
+          {
+            allParents: {
+              nodes: [
+                {
+                  id: 1,
+                  childrenByParentId: { nodes: iderize(1001) },
+                },
+                {
+                  id: 2,
+                  childrenByParentId: { nodes: iderize(2001, 2002) },
+                },
+              ],
+            },
           },
-        },
-      ),
-    );
+        ),
+      );
 
-    test(
-      "Includes only archived parents (and all their children) when EXCLUSIVELY",
-      check(
-        `{
-          allParents(includeArchived: EXCLUSIVELY) {
+      test(
+        "Includes only archived parents (and all their children) when EXCLUSIVELY",
+        check(
+          `{
+          allParents(include${Keyword}: EXCLUSIVELY) {
             nodes {
               id
               childrenByParentId {
@@ -296,129 +346,129 @@ describe("connections", () => {
             }
           }
         }`,
-        {
-          allParents: {
-            nodes: [
-              {
-                id: 2,
-                childrenByParentId: { nodes: iderize(2001, 2002) },
-              },
-            ],
+          {
+            allParents: {
+              nodes: [
+                {
+                  id: 2,
+                  childrenByParentId: { nodes: iderize(2001, 2002) },
+                },
+              ],
+            },
           },
-        },
-      ),
-    );
+        ),
+      );
+    });
   });
-});
 
-describe("simple collections", () => {
-  describe("parents", () => {
-    test(
-      "Omits archived parents by default",
-      check(
-        `{
+  describe("simple collections", () => {
+    describe("parents", () => {
+      test(
+        "Omits archived parents by default",
+        check(
+          `{
           allParentsList {
             id
           }
         }`,
-        { allParentsList: iderize(1) },
-      ),
-    );
+          { allParentsList: iderize(1) },
+        ),
+      );
 
-    test(
-      "Omits archived parents when NO",
-      check(
-        `{
-          allParentsList(includeArchived: NO) {
+      test(
+        "Omits archived parents when NO",
+        check(
+          `{
+          allParentsList(include${Keyword}: NO) {
             id
           }
         }`,
-        { allParentsList: iderize(1) },
-      ),
-    );
+          { allParentsList: iderize(1) },
+        ),
+      );
 
-    test(
-      "Includes everything when YES",
-      check(
-        `{
-          allParentsList(includeArchived: YES) {
+      test(
+        "Includes everything when YES",
+        check(
+          `{
+          allParentsList(include${Keyword}: YES) {
             id
           }
         }`,
-        { allParentsList: iderize(1, 2) },
-      ),
-    );
+          { allParentsList: iderize(1, 2) },
+        ),
+      );
 
-    test(
-      "Includes only archived when EXCLUSIVELY",
-      check(
-        `{
-          allParentsList(includeArchived: EXCLUSIVELY) {
+      test(
+        "Includes only archived when EXCLUSIVELY",
+        check(
+          `{
+          allParentsList(include${Keyword}: EXCLUSIVELY) {
             id
           }
         }`,
-        { allParentsList: iderize(2) },
-      ),
-    );
-  });
+          { allParentsList: iderize(2) },
+        ),
+      );
+    });
 
-  describe("children", () => {
-    test(
-      "Omits archived children by default",
-      check(
-        `{
+    describe("children", () => {
+      test(
+        "Omits archived children by default",
+        check(
+          `{
           allChildrenList {
             id
           }
         }`,
-        { allChildrenList: iderize(1001, 2001) },
-      ),
-    );
+          { allChildrenList: iderize(1001, 2001) },
+        ),
+      );
 
-    test(
-      "Omits archived children when NO",
-      check(
-        `{
-          allChildrenList(includeArchived: NO) {
+      test(
+        "Omits archived children when NO",
+        check(
+          `{
+          allChildrenList(include${Keyword}: NO) {
             id
           }
         }`,
-        { allChildrenList: iderize(1001, 2001) },
-      ),
-    );
+          { allChildrenList: iderize(1001, 2001) },
+        ),
+      );
 
-    test(
-      "Includes everything when YES",
-      check(
-        `{
-          allChildrenList(includeArchived: YES) {
+      test(
+        "Includes everything when YES",
+        check(
+          `{
+          allChildrenList(include${Keyword}: YES) {
             id
           }
         }`,
-        {
-          allChildrenList: iderize(1001, 1002, 2001, 2002),
-        },
-      ),
-    );
+          {
+            allChildrenList: iderize(1001, 1002, 2001, 2002),
+          },
+        ),
+      );
 
-    test(
-      "Includes only archived when EXCLUSIVELY",
-      check(
-        `{
-          allChildrenList(includeArchived: EXCLUSIVELY) {
+      test(
+        "Includes only archived when EXCLUSIVELY",
+        check(
+          `{
+          allChildrenList(include${Keyword}: EXCLUSIVELY) {
             id
           }
         }`,
-        { allChildrenList: iderize(1002, 2002) },
-      ),
-    );
-  });
+          { allChildrenList: iderize(1002, 2002) },
+        ),
+      );
+    });
 
-  describe("children of parents", () => {
-    test(
-      "Omits archived parents and children by default",
-      check(
-        `{
+    describe("children of parents", () => {
+      test(
+        "Omits archived parents and children by default",
+        check(
+          `{
           allParentsList {
             id
             childrenByParentIdList {
@@ -426,85 +476,86 @@ describe("simple collections", () => {
             }
           }
         }`,
-        {
-          allParentsList: [
-            {
-              id: 1,
-              childrenByParentIdList: iderize(1001),
-            },
-          ],
-        },
-      ),
-    );
+          {
+            allParentsList: [
+              {
+                id: 1,
+                childrenByParentIdList: iderize(1001),
+              },
+            ],
+          },
+        ),
+      );
 
-    test(
-      "Omits archived parents and children when NO",
-      check(
-        `{
-          allParentsList(includeArchived: NO) {
+      test(
+        "Omits archived parents and children when NO",
+        check(
+          `{
+          allParentsList(include${Keyword}: NO) {
             id
             childrenByParentIdList {
               id
             }
           }
         }`,
-        {
-          allParentsList: [
-            {
-              id: 1,
-              childrenByParentIdList: iderize(1001),
-            },
-          ],
-        },
-      ),
-    );
+          {
+            allParentsList: [
+              {
+                id: 1,
+                childrenByParentIdList: iderize(1001),
+              },
+            ],
+          },
+        ),
+      );
 
-    test(
-      "Includes all parents, and treats children as INHERIT (all children of an archived parent, but only the unarchived children of an unarchived parent) when YES",
-      check(
-        `{
-          allParentsList(includeArchived: YES) {
+      test(
+        "Includes all parents, and treats children as INHERIT (all children of an archived parent, but only the unarchived children of an unarchived parent) when YES",
+        check(
+          `{
+          allParentsList(include${Keyword}: YES) {
             id
             childrenByParentIdList {
               id
             }
           }
         }`,
-        {
-          allParentsList: [
-            {
-              id: 1,
-              childrenByParentIdList: iderize(1001),
-            },
-            {
-              id: 2,
-              childrenByParentIdList: iderize(2001, 2002),
-            },
-          ],
-        },
-      ),
-    );
+          {
+            allParentsList: [
+              {
+                id: 1,
+                childrenByParentIdList: iderize(1001),
+              },
+              {
+                id: 2,
+                childrenByParentIdList: iderize(2001, 2002),
+              },
+            ],
+          },
+        ),
+      );
 
-    test(
-      "Includes only archived parents (and all their children) when EXCLUSIVELY",
-      check(
-        `{
-          allParentsList(includeArchived: EXCLUSIVELY) {
+      test(
+        "Includes only archived parents (and all their children) when EXCLUSIVELY",
+        check(
+          `{
+          allParentsList(include${Keyword}: EXCLUSIVELY) {
             id
             childrenByParentIdList {
               id
             }
           }
         }`,
-        {
-          allParentsList: [
-            {
-              id: 2,
-              childrenByParentIdList: iderize(2001, 2002),
-            },
-          ],
-        },
-      ),
-    );
+          {
+            allParentsList: [
+              {
+                id: 2,
+                childrenByParentIdList: iderize(2001, 2002),
+              },
+            ],
+          },
+        ),
+      );
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prepack": "rm -Rf dist && yarn build",
     "build": "tsc",
-    "test": "jest"
+    "test": "tsc && jest"
   },
   "keywords": [
     "postgraphile",
@@ -36,10 +36,7 @@
     "prettier": "^2.2.1",
     "typescript": "^4.1.5"
   },
-  "files": [
-    "src",
-    "dist"
-  ],
+  "files": ["src", "dist"],
   "prettier": {
     "trailingComma": "all",
     "proseWrap": "always"


### PR DESCRIPTION
This plugin was built expecting to hide things when `true` (boolean) or non-null (e.g. nullable timestamp) - this works well for things like `is_archived`, `deleted_at`, and `is_template`. However sometimes you want this inverse of this behaviour; e.g. if your column is `published_at` you'd want it visible when non-null and hidden when null.

This PR enables users to invert the behaviour by adding the `pg<Keyword>ColumnImpliesVisible: true` setting to `graphileBuildOptions`.

This work was sponsored by Fielda - thanks! :pray: 