### PR TITLE
feat: omit records from table that belong to an archived record

### DIFF
--- a/__tests__/main.js
+++ b/__tests__/main.js
@@ -88,7 +88,7 @@ describe.each([
     {
       pgDraftColumnName: "is_published",
       pgDraftColumnImpliesVisible: true,
-      pgArchivedRelations: true,
+      pgDraftRelations: true,
     },
   ],
   [
@@ -97,7 +97,7 @@ describe.each([
     {
       pgDraftColumnName: "published_at",
       pgDraftColumnImpliesVisible: true,
-      pgArchivedRelations: true,
+      pgDraftRelations: true,
     },
   ],
 ])("%s", (_columnName, keyword, graphileBuildOptions) => {
@@ -581,7 +581,21 @@ describe.each([
 
   if (graphileBuildOptions && graphileBuildOptions.pgArchivedRelations) {
     describe("pgArchivedRelations", () => {
-      it.todo("Defaults to omitting other_children where parent is archived");
+      it(
+        "Defaults to omitting other_children where parent is archived",
+        check(
+          /* GraphQL */ `
+            {
+              allOtherChildrenList {
+                id
+              }
+            }
+          `,
+          {
+            allOtherChildrenList: iderize(101, 102),
+          },
+        ),
+      );
       it.todo("Includes only other_children of non-archived parents when NO");
       it.todo("Includes all other_children of all parents when YES");
       it.todo(

--- a/__tests__/main.js
+++ b/__tests__/main.js
@@ -646,6 +646,112 @@ describe.each([
           },
         ),
       );
+
+      it(
+        "Includes all other children that are related by default (due to INHERIT)",
+        check(
+          /* GraphQL */ `
+            {
+              allParentsList(include${Keyword}: YES) {
+                id
+                otherChildrenByParentIdList {
+                  id
+                }
+              }
+            }
+          `,
+          {
+            allParentsList: [
+              { id: 1, otherChildrenByParentIdList: iderize(101, 102) },
+              { id: 2, otherChildrenByParentIdList: iderize(201, 202) },
+            ],
+          },
+        ),
+      );
+      it(
+        "Includes all other children that are related when explicitly INHERIT",
+        check(
+          /* GraphQL */ `
+            {
+              allParentsList(include${Keyword}: YES) {
+                id
+                otherChildrenByParentIdList(include${Keyword}: INHERIT) {
+                  id
+                }
+              }
+            }
+          `,
+          {
+            allParentsList: [
+              { id: 1, otherChildrenByParentIdList: iderize(101, 102) },
+              { id: 2, otherChildrenByParentIdList: iderize(201, 202) },
+            ],
+          },
+        ),
+      );
+      it(
+        "Includes archived other children within relation when explicitly YES",
+        check(
+          /* GraphQL */ `
+            {
+              allParentsList(include${Keyword}: YES) {
+                id
+                otherChildrenByParentIdList(include${Keyword}: YES) {
+                  id
+                }
+              }
+            }
+          `,
+          {
+            allParentsList: [
+              { id: 1, otherChildrenByParentIdList: iderize(101, 102) },
+              { id: 2, otherChildrenByParentIdList: iderize(201, 202) },
+            ],
+          },
+        ),
+      );
+      it(
+        "Omits archived other children within relation when explicitly NO",
+        check(
+          /* GraphQL */ `
+            {
+              allParentsList(include${Keyword}: YES) {
+                id
+                otherChildrenByParentIdList(include${Keyword}: NO) {
+                  id
+                }
+              }
+            }
+          `,
+          {
+            allParentsList: [
+              { id: 1, otherChildrenByParentIdList: iderize(101, 102) },
+              { id: 2, otherChildrenByParentIdList: [] },
+            ],
+          },
+        ),
+      );
+      it(
+        "Only ncludes archived other children within relation when explicitly EXCLUSIVELY",
+        check(
+          /* GraphQL */ `
+            {
+              allParentsList(include${Keyword}: YES) {
+                id
+                otherChildrenByParentIdList(include${Keyword}: EXCLUSIVELY) {
+                  id
+                }
+              }
+            }
+          `,
+          {
+            allParentsList: [
+              { id: 1, otherChildrenByParentIdList: [] },
+              { id: 2, otherChildrenByParentIdList: iderize(201, 202) },
+            ],
+          },
+        ),
+      );
     });
   } else {
     describe(`${pgRelationsAttr} DISABLED`, () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,13 +54,15 @@ const makeUtils = (
       : null;
 
   // It doesn't apply to us directly; do we have a relation that's relevant?
-  const relevantRelations = introspectionResultsByKind.constraint.filter(
-    (c) =>
-      c.type === "f" &&
-      c.classId === table.id &&
-      c.foreignClass &&
-      getRelevantColumn(c.foreignClass),
-  );
+  const relevantRelations = applyToRelations
+    ? introspectionResultsByKind.constraint.filter(
+        (c) =>
+          c.type === "f" &&
+          c.classId === table.id &&
+          c.foreignClass &&
+          getRelevantColumn(c.foreignClass),
+      )
+    : [];
   // Pick the first one (order by constraint name)
   const relevantRelation = relevantRelations.sort((a, z) =>
     a.name.localeCompare(z.name),

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,11 @@
 import { makePluginByCombiningPlugins } from "graphile-utils";
 import type { Build, Plugin as GraphileEnginePlugin } from "postgraphile";
 import type {
+  PgAttribute,
   PgClass,
   PgIntrospectionResultsByKind,
   QueryBuilder,
+  SQL,
 } from "graphile-build-pg";
 
 /**
@@ -36,6 +38,7 @@ const makeUtils = (
       // If true inverts the omitting logic (e.g. true for `is_published` or
       // `published_at`; false for `is_archived` or `archived_at`).
       [`pg${Keyword}ColumnImpliesVisible`]: invert = false,
+      [`pg${Keyword}Relations`]: applyToRelations = false,
     },
   } = build;
   const sql = build.pgSql as typeof import("pg-sql2");
@@ -49,7 +52,26 @@ const makeUtils = (
             attr.classId === tableToCheck.id && attr.name === columnNameToCheck,
         )
       : null;
-  const relevantColumn = getRelevantColumn(table);
+
+  // It doesn't apply to us directly; do we have a relation that's relevant?
+  const relevantRelations = introspectionResultsByKind.constraint.filter(
+    (c) =>
+      c.type === "f" &&
+      c.classId === table.id &&
+      c.foreignClass &&
+      getRelevantColumn(c.foreignClass),
+  );
+  // Pick the first one (order by constraint name)
+  const relevantRelation = relevantRelations.sort((a, z) =>
+    a.name.localeCompare(z.name),
+  )[0];
+
+  const relevantColumn =
+    getRelevantColumn(table) ||
+    (relevantRelation && relevantRelation.foreignClass
+      ? getRelevantColumn(relevantRelation.foreignClass)
+      : null);
+
   if (!relevantColumn) {
     return null;
   }
@@ -99,7 +121,17 @@ const makeUtils = (
       : [nullableVisibleFragment, nullableInvisibleFragment];
 
   function addWhereClause(queryBuilder: QueryBuilder, fieldArgs: any) {
+    // TypeScript hack
+    if (!relevantColumn) {
+      return;
+    }
     const { [`include${Keyword}`]: relevantSetting } = fieldArgs;
+    let fragment: SQL | null = null;
+
+    const myAlias =
+      relevantColumn.class !== table
+        ? sql.identifier(Symbol("me"))
+        : queryBuilder.getTableAlias();
     if (
       capableOfInherit &&
       relevantSetting === "INHERIT" &&
@@ -107,29 +139,47 @@ const makeUtils = (
       parentColumnDetails
     ) {
       const sqlParentTableAlias = queryBuilder.parentQueryBuilder.getTableAlias();
-      queryBuilder.where(
-        sql.fragment`(${sqlParentTableAlias}.${sql.identifier(
-          parentColumnDetails.name,
-        )} is ${parentInvisibleFragment} or ${queryBuilder.getTableAlias()}.${sql.identifier(
-          columnDetails.name,
-        )} is ${visibleFragment})`,
-      );
+      fragment = sql.fragment`(${sqlParentTableAlias}.${sql.identifier(
+        parentColumnDetails.name,
+      )} is ${parentInvisibleFragment} or ${myAlias}.${sql.identifier(
+        columnDetails.name,
+      )} is ${visibleFragment})`;
     } else if (
       relevantSetting === "NO" ||
       // INHERIT is equivalent to NO if there's no valid parent
       relevantSetting === "INHERIT"
     ) {
-      queryBuilder.where(
-        sql.fragment`${queryBuilder.getTableAlias()}.${sql.identifier(
-          columnDetails.name,
-        )} is ${visibleFragment}`,
-      );
+      fragment = sql.fragment`${myAlias}.${sql.identifier(
+        columnDetails.name,
+      )} is ${visibleFragment}`;
     } else if (relevantSetting === "EXCLUSIVELY") {
-      queryBuilder.where(
-        sql.fragment`${queryBuilder.getTableAlias()}.${sql.identifier(
-          columnDetails.name,
-        )} is ${invisibleFragment}`,
-      );
+      fragment = sql.fragment`${myAlias}.${sql.identifier(
+        columnDetails.name,
+      )} is ${invisibleFragment}`;
+    }
+    if (fragment) {
+      if (relevantRelation && relevantColumn.class !== table) {
+        const localAlias = queryBuilder.getTableAlias();
+        const relationConditions = relevantRelation.keyAttributes.map(
+          (attr, i) => {
+            const otherAttr = relevantRelation.foreignKeyAttributes[i];
+            return sql.fragment`${localAlias}.${sql.identifier(
+              attr.name,
+            )} = ${myAlias}.${sql.identifier(otherAttr.name)}`;
+          },
+        );
+        queryBuilder.where(
+          sql.fragment`(select ${fragment} from ${sql.identifier(
+            relevantColumn.class.namespaceName,
+            relevantColumn.class.name,
+          )} as ${myAlias} where (${sql.join(
+            relationConditions,
+            ") and (",
+          )})) is true`,
+        );
+      } else {
+        queryBuilder.where(fragment);
+      }
     }
   }
   return {


### PR DESCRIPTION
Normally we only exclude archived items from tables that have an `is_archived` (or similar) column. Sometimes, however, it's useful to also exclude related records; for example if you archive a `forum` then the `posts` should automatically be treated as if they were explicitly archived even if you've not denormalized the `is_archived` column onto them (which is the most performant read-time way to handle it, but could give you write time performance issues - especially if your forum has millions of posts in it). This PR adds the `pgArchivedRelations` option which you can set `true` so tables that "belong to" a table with an `is_archived` column also gain the `includeArchived` GraphQL field and behaviour.

This feature trades read-time performance for write-time performance; in many web contexts read-time performance is a larger concern and in these cases I'd encourage denormalization.