### PR TITLE
fix(relations): use constraint-based name for relations

### DIFF
--- a/__tests__/main.js
+++ b/__tests__/main.js
@@ -155,12 +155,12 @@ describe.each([
         "Omits archived parents by default",
         check(
           `{
-          allParents {
-            nodes {
-              id
+            allParents {
+              nodes {
+                id
+              }
             }
-          }
-        }`,
+          }`,
           { allParents: { nodes: iderize(1) } },
         ),
       );
@@ -169,12 +169,12 @@ describe.each([
         "Omits archived parents when NO",
         check(
           `{
-          allParents(include${Keyword}: NO) {
-            nodes {
-              id
+            allParents(include${Keyword}: NO) {
+              nodes {
+                id
+              }
             }
-          }
-        }`,
+          }`,
           { allParents: { nodes: iderize(1) } },
         ),
       );
@@ -183,12 +183,12 @@ describe.each([
         "Includes everything when YES",
         check(
           `{
-          allParents(include${Keyword}: YES) {
-            nodes {
-              id
+            allParents(include${Keyword}: YES) {
+              nodes {
+                id
+              }
             }
-          }
-        }`,
+          }`,
           { allParents: { nodes: iderize(1, 2) } },
         ),
       );
@@ -197,12 +197,12 @@ describe.each([
         "Includes only archived when EXCLUSIVELY",
         check(
           `{
-          allParents(include${Keyword}: EXCLUSIVELY) {
-            nodes {
-              id
+            allParents(include${Keyword}: EXCLUSIVELY) {
+              nodes {
+                id
+              }
             }
-          }
-        }`,
+          }`,
           { allParents: { nodes: iderize(2) } },
         ),
       );
@@ -214,12 +214,12 @@ describe.each([
           "Omits archived children (and those with archived parents) by default",
           check(
             `{
-          allChildren {
-            nodes {
-              id
-            }
-          }
-        }`,
+              allChildren {
+                nodes {
+                  id
+                }
+              }
+            }`,
             { allChildren: { nodes: iderize(1001) } },
           ),
         );
@@ -228,12 +228,12 @@ describe.each([
           "Omits archived children by default",
           check(
             `{
-          allChildren {
-            nodes {
-              id
-            }
-          }
-        }`,
+              allChildren {
+                nodes {
+                  id
+                }
+              }
+            }`,
             { allChildren: { nodes: iderize(1001, 2001) } },
           ),
         );
@@ -244,12 +244,12 @@ describe.each([
           "Omits archived children (and those with archived parents) when NO",
           check(
             `{
-          allChildren(include${Keyword}: NO) {
-            nodes {
-              id
-            }
-          }
-        }`,
+              allChildren(include${Keyword}: NO) {
+                nodes {
+                  id
+                }
+              }
+            }`,
             { allChildren: { nodes: iderize(1001) } },
           ),
         );
@@ -258,12 +258,12 @@ describe.each([
           "Omits archived children when NO",
           check(
             `{
-          allChildren(include${Keyword}: NO) {
-            nodes {
-              id
-            }
-          }
-        }`,
+              allChildren(include${Keyword}: NO) {
+                nodes {
+                  id
+                }
+              }
+            }`,
             { allChildren: { nodes: iderize(1001, 2001) } },
           ),
         );
@@ -386,17 +386,17 @@ describe.each([
         "Omits archived parents and children by default",
         check(
           `{
-          allParents {
-            nodes {
-              id
-              childrenByParentId {
-                nodes {
-                  id
+            allParents {
+              nodes {
+                id
+                childrenByParentId {
+                  nodes {
+                    id
+                  }
                 }
               }
             }
-          }
-        }`,
+          }`,
           {
             allParents: {
               nodes: [
@@ -414,17 +414,17 @@ describe.each([
         "Omits archived parents and children when NO",
         check(
           `{
-          allParents(include${Keyword}: NO) {
-            nodes {
-              id
-              childrenByParentId {
-                nodes {
-                  id
+            allParents(include${Keyword}: NO) {
+              nodes {
+                id
+                childrenByParentId {
+                  nodes {
+                    id
+                  }
                 }
               }
             }
-          }
-        }`,
+          }`,
           {
             allParents: {
               nodes: [
@@ -442,17 +442,17 @@ describe.each([
         "Includes all parents, and treats children as INHERIT (all children of an archived parent, but only the unarchived children of an unarchived parent) when YES",
         check(
           `{
-          allParents(include${Keyword}: YES) {
-            nodes {
-              id
-              childrenByParentId {
-                nodes {
-                  id
+            allParents(include${Keyword}: YES) {
+              nodes {
+                id
+                childrenByParentId {
+                  nodes {
+                    id
+                  }
                 }
               }
             }
-          }
-        }`,
+          }`,
           {
             allParents: {
               nodes: [
@@ -474,17 +474,17 @@ describe.each([
         "Includes only archived parents (and all their children) when EXCLUSIVELY",
         check(
           `{
-          allParents(include${Keyword}: EXCLUSIVELY) {
-            nodes {
-              id
-              childrenByParentId {
-                nodes {
-                  id
+            allParents(include${Keyword}: EXCLUSIVELY) {
+              nodes {
+                id
+                childrenByParentId {
+                  nodes {
+                    id
+                  }
                 }
               }
             }
-          }
-        }`,
+          }`,
           {
             allParents: {
               nodes: [
@@ -506,10 +506,10 @@ describe.each([
         "Omits archived parents by default",
         check(
           `{
-          allParentsList {
-            id
-          }
-        }`,
+            allParentsList {
+              id
+            }
+          }`,
           { allParentsList: iderize(1) },
         ),
       );
@@ -518,10 +518,10 @@ describe.each([
         "Omits archived parents when NO",
         check(
           `{
-          allParentsList(include${Keyword}: NO) {
-            id
-          }
-        }`,
+            allParentsList(include${Keyword}: NO) {
+              id
+            }
+          }`,
           { allParentsList: iderize(1) },
         ),
       );
@@ -530,10 +530,10 @@ describe.each([
         "Includes everything when YES",
         check(
           `{
-          allParentsList(include${Keyword}: YES) {
-            id
-          }
-        }`,
+            allParentsList(include${Keyword}: YES) {
+              id
+            }
+          }`,
           { allParentsList: iderize(1, 2) },
         ),
       );
@@ -542,10 +542,10 @@ describe.each([
         "Includes only archived when EXCLUSIVELY",
         check(
           `{
-          allParentsList(include${Keyword}: EXCLUSIVELY) {
-            id
-          }
-        }`,
+            allParentsList(include${Keyword}: EXCLUSIVELY) {
+              id
+            }
+          }`,
           { allParentsList: iderize(2) },
         ),
       );
@@ -701,13 +701,13 @@ describe.each([
         "Omits archived parents and children by default",
         check(
           `{
-          allParentsList {
-            id
-            childrenByParentIdList {
+            allParentsList {
               id
+              childrenByParentIdList {
+                id
+              }
             }
-          }
-        }`,
+          }`,
           {
             allParentsList: [
               {
@@ -723,13 +723,13 @@ describe.each([
         "Omits archived parents and children when NO",
         check(
           `{
-          allParentsList(include${Keyword}: NO) {
-            id
-            childrenByParentIdList {
+            allParentsList(include${Keyword}: NO) {
               id
+              childrenByParentIdList {
+                id
+              }
             }
-          }
-        }`,
+          }`,
           {
             allParentsList: [
               {
@@ -745,13 +745,13 @@ describe.each([
         "Includes all parents, and treats children as INHERIT (all children of an archived parent, but only the unarchived children of an unarchived parent) when YES",
         check(
           `{
-          allParentsList(include${Keyword}: YES) {
-            id
-            childrenByParentIdList {
+            allParentsList(include${Keyword}: YES) {
               id
+              childrenByParentIdList {
+                id
+              }
             }
-          }
-        }`,
+          }`,
           {
             allParentsList: [
               {
@@ -771,13 +771,13 @@ describe.each([
         "Includes only archived parents (and all their children) when EXCLUSIVELY",
         check(
           `{
-          allParentsList(include${Keyword}: EXCLUSIVELY) {
-            id
-            childrenByParentIdList {
+            allParentsList(include${Keyword}: EXCLUSIVELY) {
               id
+              childrenByParentIdList {
+                id
+              }
             }
-          }
-        }`,
+          }`,
           {
             allParentsList: [
               {

--- a/src/index.ts
+++ b/src/index.ts
@@ -365,7 +365,7 @@ const generator = (keyword = "archived"): GraphileEnginePlugin => {
         const allUtils = selfAndConstraints.map((relation) =>
           makeUtils(build, keyword, table, parentTable, allowInherit, relation),
         );
-        if (!allUtils || allUtils.length === 0) {
+        if (!allUtils) {
           return args;
         }
         return allUtils.reduce((args, utils) => {


### PR DESCRIPTION
We introduced the `pgArchivedRelations` in the previous release candidate but it wasn't quite fit for purpose because it doesn't combine well with parent attributes; e.g. if you have a forum that has `is_archived` and you have posts within that forum that have their own `is_archived` then the posts' is_archived would be respected only, and the forum is_archived would be ignored when fetching posts. Ideally the posts is_archived should be updated to match the forums, but this has two issues:

1. it loses data - if we un-archive the forum we don't want to un-archive all the previously manually archived posts, only those that were archived because we archived the forum
2. updating `is_archived` on every post within the forum could be an expensive operation - especially if there's millions of records.

This PR changes the `pgArchivedRelations` functionality introduced on Wednesday to use a different argument name depending on the relation and respect all "belongs to" relations rather than just the alphabetically first one.

:rotating_light: This is a breaking change versus 3.0.0-rc.2 and 3.0.0-rc.3 if you're already using the pgArchivedRelations feature - sorry!