### PR TITLE
feat(relations): allow enabling for specific relation via smart-tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,9 @@ By default this plugin only adds the `include<Keyword>` (e.g. `includeArchived`)
 argument to collections for tables that have the relevant (e.g. `is_archived`)
 column. Sometimes however you want to expand this behaviour to tables that
 "belong to" this table. To achieve this, use the `pg<Keyword>Relations: true`
-(e.g. `pgArchivedRelations: true`) option, and we'll add an argument like
+(e.g. `pgArchivedRelations: true`) option (or for more granular control use the
+`@<keyword>Relation` (e.g. `@archivedRelation`) smart comment/smart tag on the
+relevant foreign key constraint), and we'll add an argument like
 `includeWhen<Relation><Keyword>` (e.g. `includeWhenParentByParentIdArchived`).
 You should use this sparingly as it's not implemented particularly efficiently,
 and it also will make your schema somewhat larger/more complex.

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ const makeUtils = (
       : null;
 
   if (relevantRelation) {
-    if (!applyToRelations) {
+    if (!applyToRelations && !relevantRelation.tags[`${keyword}Relation`]) {
       return null;
     }
     if (


### PR DESCRIPTION
Enhancement to the pgArchivedRelations feature that means you can leave it off globally but then enable it on a relation-by-relation basis with a smart comment/smart tag e.g. `comment on constraint my_fk on table my_table is E'@archivedRelations';`