### PR TITLE
feat: allow specifying an expression to omit rows

### DIFF
--- a/__tests__/__snapshots__/main.js.snap
+++ b/__tests__/__snapshots__/main.js.snap
@@ -14,6 +14,7 @@ type Child implements Node {
   archivedAt: Datetime
   isPublished: Boolean!
   publishedAt: Datetime
+  status: String!
 
   """Reads a single \`Organization\` that is related to this \`Child\`."""
   organizationByOrganizationId: Organization
@@ -49,6 +50,9 @@ input ChildCondition {
 
   """Checks for equality with the object’s \`publishedAt\` field."""
   publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
 }
 
 """An input for mutations affecting \`Child\`"""
@@ -61,6 +65,7 @@ input ChildInput {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String!
 }
 
 """
@@ -75,6 +80,7 @@ input ChildPatch {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String
 }
 
 """A connection to a list of \`Child\` values."""
@@ -122,6 +128,8 @@ enum ChildrenOrderBy {
   IS_PUBLISHED_DESC
   PUBLISHED_AT_ASC
   PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -693,6 +701,7 @@ type Organization implements Node {
   archivedAt: Datetime
   isPublished: Boolean!
   publishedAt: Datetime
+  status: String!
 
   """Reads and enables pagination through a set of \`Child\`."""
   childrenByOrganizationId(
@@ -793,6 +802,9 @@ input OrganizationCondition {
 
   """Checks for equality with the object’s \`publishedAt\` field."""
   publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
 }
 
 """An input for mutations affecting \`Organization\`"""
@@ -803,6 +815,7 @@ input OrganizationInput {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String!
 }
 
 """
@@ -815,6 +828,7 @@ input OrganizationPatch {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String
 }
 
 """A connection to a list of \`Organization\` values."""
@@ -858,6 +872,8 @@ enum OrganizationsOrderBy {
   IS_PUBLISHED_DESC
   PUBLISHED_AT_ASC
   PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -971,6 +987,7 @@ type Parent implements Node {
   archivedAt: Datetime
   isPublished: Boolean!
   publishedAt: Datetime
+  status: String!
 
   """Reads and enables pagination through a set of \`Child\`."""
   childrenByParentId(
@@ -1126,6 +1143,9 @@ input ParentCondition {
 
   """Checks for equality with the object’s \`publishedAt\` field."""
   publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
 }
 
 """An input for mutations affecting \`Parent\`"""
@@ -1136,6 +1156,7 @@ input ParentInput {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String!
 }
 
 """
@@ -1148,6 +1169,7 @@ input ParentPatch {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String
 }
 
 """A connection to a list of \`Parent\` values."""
@@ -1191,6 +1213,8 @@ enum ParentsOrderBy {
   IS_PUBLISHED_DESC
   PUBLISHED_AT_ASC
   PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -1744,6 +1768,7 @@ type Child implements Node {
   archivedAt: Datetime
   isPublished: Boolean!
   publishedAt: Datetime
+  status: String!
 
   """Reads a single \`Organization\` that is related to this \`Child\`."""
   organizationByOrganizationId: Organization
@@ -1779,6 +1804,9 @@ input ChildCondition {
 
   """Checks for equality with the object’s \`publishedAt\` field."""
   publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
 }
 
 """An input for mutations affecting \`Child\`"""
@@ -1791,6 +1819,7 @@ input ChildInput {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String!
 }
 
 """
@@ -1805,6 +1834,7 @@ input ChildPatch {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String
 }
 
 """A connection to a list of \`Child\` values."""
@@ -1852,6 +1882,8 @@ enum ChildrenOrderBy {
   IS_PUBLISHED_DESC
   PUBLISHED_AT_ASC
   PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -2423,6 +2455,7 @@ type Organization implements Node {
   archivedAt: Datetime
   isPublished: Boolean!
   publishedAt: Datetime
+  status: String!
 
   """Reads and enables pagination through a set of \`Child\`."""
   childrenByOrganizationId(
@@ -2503,6 +2536,9 @@ input OrganizationCondition {
 
   """Checks for equality with the object’s \`publishedAt\` field."""
   publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
 }
 
 """An input for mutations affecting \`Organization\`"""
@@ -2513,6 +2549,7 @@ input OrganizationInput {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String!
 }
 
 """
@@ -2525,6 +2562,7 @@ input OrganizationPatch {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String
 }
 
 """A connection to a list of \`Organization\` values."""
@@ -2568,6 +2606,8 @@ enum OrganizationsOrderBy {
   IS_PUBLISHED_DESC
   PUBLISHED_AT_ASC
   PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -2681,6 +2721,7 @@ type Parent implements Node {
   archivedAt: Datetime
   isPublished: Boolean!
   publishedAt: Datetime
+  status: String!
 
   """Reads and enables pagination through a set of \`Child\`."""
   childrenByParentId(
@@ -2806,6 +2847,9 @@ input ParentCondition {
 
   """Checks for equality with the object’s \`publishedAt\` field."""
   publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
 }
 
 """An input for mutations affecting \`Parent\`"""
@@ -2816,6 +2860,7 @@ input ParentInput {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String!
 }
 
 """
@@ -2828,6 +2873,7 @@ input ParentPatch {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String
 }
 
 """A connection to a list of \`Parent\` values."""
@@ -2871,6 +2917,8 @@ enum ParentsOrderBy {
   IS_PUBLISHED_DESC
   PUBLISHED_AT_ASC
   PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -3394,6 +3442,7 @@ type Child implements Node {
   archivedAt: Datetime
   isPublished: Boolean!
   publishedAt: Datetime
+  status: String!
 
   """Reads a single \`Organization\` that is related to this \`Child\`."""
   organizationByOrganizationId: Organization
@@ -3429,6 +3478,9 @@ input ChildCondition {
 
   """Checks for equality with the object’s \`publishedAt\` field."""
   publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
 }
 
 """An input for mutations affecting \`Child\`"""
@@ -3441,6 +3493,7 @@ input ChildInput {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String!
 }
 
 """
@@ -3455,6 +3508,7 @@ input ChildPatch {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String
 }
 
 """A connection to a list of \`Child\` values."""
@@ -3502,6 +3556,8 @@ enum ChildrenOrderBy {
   IS_PUBLISHED_DESC
   PUBLISHED_AT_ASC
   PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -4073,6 +4129,7 @@ type Organization implements Node {
   archivedAt: Datetime
   isPublished: Boolean!
   publishedAt: Datetime
+  status: String!
 
   """Reads and enables pagination through a set of \`Child\`."""
   childrenByOrganizationId(
@@ -4163,6 +4220,9 @@ input OrganizationCondition {
 
   """Checks for equality with the object’s \`publishedAt\` field."""
   publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
 }
 
 """An input for mutations affecting \`Organization\`"""
@@ -4173,6 +4233,7 @@ input OrganizationInput {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String!
 }
 
 """
@@ -4185,6 +4246,7 @@ input OrganizationPatch {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String
 }
 
 """A connection to a list of \`Organization\` values."""
@@ -4228,6 +4290,8 @@ enum OrganizationsOrderBy {
   IS_PUBLISHED_DESC
   PUBLISHED_AT_ASC
   PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -4341,6 +4405,7 @@ type Parent implements Node {
   archivedAt: Datetime
   isPublished: Boolean!
   publishedAt: Datetime
+  status: String!
 
   """Reads and enables pagination through a set of \`Child\`."""
   childrenByParentId(
@@ -4476,6 +4541,9 @@ input ParentCondition {
 
   """Checks for equality with the object’s \`publishedAt\` field."""
   publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
 }
 
 """An input for mutations affecting \`Parent\`"""
@@ -4486,6 +4554,7 @@ input ParentInput {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String!
 }
 
 """
@@ -4498,6 +4567,7 @@ input ParentPatch {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String
 }
 
 """A connection to a list of \`Parent\` values."""
@@ -4541,6 +4611,8 @@ enum ParentsOrderBy {
   IS_PUBLISHED_DESC
   PUBLISHED_AT_ASC
   PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -5074,6 +5146,7 @@ type Child implements Node {
   archivedAt: Datetime
   isPublished: Boolean!
   publishedAt: Datetime
+  status: String!
 
   """Reads a single \`Organization\` that is related to this \`Child\`."""
   organizationByOrganizationId: Organization
@@ -5109,6 +5182,9 @@ input ChildCondition {
 
   """Checks for equality with the object’s \`publishedAt\` field."""
   publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
 }
 
 """An input for mutations affecting \`Child\`"""
@@ -5121,6 +5197,7 @@ input ChildInput {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String!
 }
 
 """
@@ -5135,6 +5212,7 @@ input ChildPatch {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String
 }
 
 """A connection to a list of \`Child\` values."""
@@ -5182,6 +5260,8 @@ enum ChildrenOrderBy {
   IS_PUBLISHED_DESC
   PUBLISHED_AT_ASC
   PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -5753,6 +5833,7 @@ type Organization implements Node {
   archivedAt: Datetime
   isPublished: Boolean!
   publishedAt: Datetime
+  status: String!
 
   """Reads and enables pagination through a set of \`Child\`."""
   childrenByOrganizationId(
@@ -5853,6 +5934,9 @@ input OrganizationCondition {
 
   """Checks for equality with the object’s \`publishedAt\` field."""
   publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
 }
 
 """An input for mutations affecting \`Organization\`"""
@@ -5863,6 +5947,7 @@ input OrganizationInput {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String!
 }
 
 """
@@ -5875,6 +5960,7 @@ input OrganizationPatch {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String
 }
 
 """A connection to a list of \`Organization\` values."""
@@ -5918,6 +6004,8 @@ enum OrganizationsOrderBy {
   IS_PUBLISHED_DESC
   PUBLISHED_AT_ASC
   PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -6031,6 +6119,7 @@ type Parent implements Node {
   archivedAt: Datetime
   isPublished: Boolean!
   publishedAt: Datetime
+  status: String!
 
   """Reads and enables pagination through a set of \`Child\`."""
   childrenByParentId(
@@ -6186,6 +6275,9 @@ input ParentCondition {
 
   """Checks for equality with the object’s \`publishedAt\` field."""
   publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
 }
 
 """An input for mutations affecting \`Parent\`"""
@@ -6196,6 +6288,7 @@ input ParentInput {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String!
 }
 
 """
@@ -6208,6 +6301,7 @@ input ParentPatch {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String
 }
 
 """A connection to a list of \`Parent\` values."""
@@ -6251,6 +6345,8 @@ enum ParentsOrderBy {
   IS_PUBLISHED_DESC
   PUBLISHED_AT_ASC
   PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -6804,6 +6900,7 @@ type Child implements Node {
   archivedAt: Datetime
   isPublished: Boolean!
   publishedAt: Datetime
+  status: String!
 
   """Reads a single \`Organization\` that is related to this \`Child\`."""
   organizationByOrganizationId: Organization
@@ -6839,6 +6936,9 @@ input ChildCondition {
 
   """Checks for equality with the object’s \`publishedAt\` field."""
   publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
 }
 
 """An input for mutations affecting \`Child\`"""
@@ -6851,6 +6951,7 @@ input ChildInput {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String!
 }
 
 """
@@ -6865,6 +6966,7 @@ input ChildPatch {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String
 }
 
 """A connection to a list of \`Child\` values."""
@@ -6912,6 +7014,8 @@ enum ChildrenOrderBy {
   IS_PUBLISHED_DESC
   PUBLISHED_AT_ASC
   PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -7483,6 +7587,7 @@ type Organization implements Node {
   archivedAt: Datetime
   isPublished: Boolean!
   publishedAt: Datetime
+  status: String!
 
   """Reads and enables pagination through a set of \`Child\`."""
   childrenByOrganizationId(
@@ -7583,6 +7688,9 @@ input OrganizationCondition {
 
   """Checks for equality with the object’s \`publishedAt\` field."""
   publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
 }
 
 """An input for mutations affecting \`Organization\`"""
@@ -7593,6 +7701,7 @@ input OrganizationInput {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String!
 }
 
 """
@@ -7605,6 +7714,7 @@ input OrganizationPatch {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String
 }
 
 """A connection to a list of \`Organization\` values."""
@@ -7648,6 +7758,8 @@ enum OrganizationsOrderBy {
   IS_PUBLISHED_DESC
   PUBLISHED_AT_ASC
   PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -7761,6 +7873,7 @@ type Parent implements Node {
   archivedAt: Datetime
   isPublished: Boolean!
   publishedAt: Datetime
+  status: String!
 
   """Reads and enables pagination through a set of \`Child\`."""
   childrenByParentId(
@@ -7916,6 +8029,9 @@ input ParentCondition {
 
   """Checks for equality with the object’s \`publishedAt\` field."""
   publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
 }
 
 """An input for mutations affecting \`Parent\`"""
@@ -7926,6 +8042,7 @@ input ParentInput {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String!
 }
 
 """
@@ -7938,6 +8055,7 @@ input ParentPatch {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String
 }
 
 """A connection to a list of \`Parent\` values."""
@@ -7981,6 +8099,8 @@ enum ParentsOrderBy {
   IS_PUBLISHED_DESC
   PUBLISHED_AT_ASC
   PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -8534,6 +8654,7 @@ type Child implements Node {
   archivedAt: Datetime
   isPublished: Boolean!
   publishedAt: Datetime
+  status: String!
 
   """Reads a single \`Organization\` that is related to this \`Child\`."""
   organizationByOrganizationId: Organization
@@ -8569,6 +8690,9 @@ input ChildCondition {
 
   """Checks for equality with the object’s \`publishedAt\` field."""
   publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
 }
 
 """An input for mutations affecting \`Child\`"""
@@ -8581,6 +8705,7 @@ input ChildInput {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String!
 }
 
 """
@@ -8595,6 +8720,7 @@ input ChildPatch {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String
 }
 
 """A connection to a list of \`Child\` values."""
@@ -8642,6 +8768,8 @@ enum ChildrenOrderBy {
   IS_PUBLISHED_DESC
   PUBLISHED_AT_ASC
   PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -9213,6 +9341,7 @@ type Organization implements Node {
   archivedAt: Datetime
   isPublished: Boolean!
   publishedAt: Datetime
+  status: String!
 
   """Reads and enables pagination through a set of \`Child\`."""
   childrenByOrganizationId(
@@ -9313,6 +9442,9 @@ input OrganizationCondition {
 
   """Checks for equality with the object’s \`publishedAt\` field."""
   publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
 }
 
 """An input for mutations affecting \`Organization\`"""
@@ -9323,6 +9455,7 @@ input OrganizationInput {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String!
 }
 
 """
@@ -9335,6 +9468,7 @@ input OrganizationPatch {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String
 }
 
 """A connection to a list of \`Organization\` values."""
@@ -9378,6 +9512,8 @@ enum OrganizationsOrderBy {
   IS_PUBLISHED_DESC
   PUBLISHED_AT_ASC
   PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -9491,6 +9627,7 @@ type Parent implements Node {
   archivedAt: Datetime
   isPublished: Boolean!
   publishedAt: Datetime
+  status: String!
 
   """Reads and enables pagination through a set of \`Child\`."""
   childrenByParentId(
@@ -9646,6 +9783,9 @@ input ParentCondition {
 
   """Checks for equality with the object’s \`publishedAt\` field."""
   publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
 }
 
 """An input for mutations affecting \`Parent\`"""
@@ -9656,6 +9796,7 @@ input ParentInput {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String!
 }
 
 """
@@ -9668,6 +9809,7 @@ input ParentPatch {
   archivedAt: Datetime
   isPublished: Boolean
   publishedAt: Datetime
+  status: String
 }
 
 """A connection to a list of \`Parent\` values."""
@@ -9711,6 +9853,8 @@ enum ParentsOrderBy {
   IS_PUBLISHED_DESC
   PUBLISHED_AT_ASC
   PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -9976,6 +10120,1762 @@ type Query implements Node {
     Indicates whether draft items should be included in the results or not.
     """
     includeDraft: IncludeDraftOption = NO
+  ): [Parent!]
+  childById(id: Int!): Child
+  organizationById(id: Int!): Organization
+  otherChildById(id: Int!): OtherChild
+  parentById(id: Int!): Parent
+
+  """Reads a single \`Child\` using its globally unique \`ID\`."""
+  child(
+    """The globally unique \`ID\` to be used in selecting a single \`Child\`."""
+    nodeId: ID!
+  ): Child
+
+  """Reads a single \`Organization\` using its globally unique \`ID\`."""
+  organization(
+    """
+    The globally unique \`ID\` to be used in selecting a single \`Organization\`.
+    """
+    nodeId: ID!
+  ): Organization
+
+  """Reads a single \`OtherChild\` using its globally unique \`ID\`."""
+  otherChild(
+    """
+    The globally unique \`ID\` to be used in selecting a single \`OtherChild\`.
+    """
+    nodeId: ID!
+  ): OtherChild
+
+  """Reads a single \`Parent\` using its globally unique \`ID\`."""
+  parent(
+    """The globally unique \`ID\` to be used in selecting a single \`Parent\`."""
+    nodeId: ID!
+  ): Parent
+}
+
+"""All input for the \`updateChildById\` mutation."""
+input UpdateChildByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the \`Child\` being updated.
+  """
+  childPatch: ChildPatch!
+  id: Int!
+}
+
+"""All input for the \`updateChild\` mutation."""
+input UpdateChildInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Child\` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the \`Child\` being updated.
+  """
+  childPatch: ChildPatch!
+}
+
+"""The output of our update \`Child\` mutation."""
+type UpdateChildPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Child\` that was updated by this mutation."""
+  child: Child
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single \`Organization\` that is related to this \`Child\`."""
+  organizationByOrganizationId: Organization
+
+  """Reads a single \`Parent\` that is related to this \`Child\`."""
+  parentByParentId: Parent
+
+  """An edge for our \`Child\`. May be used by Relay 1."""
+  childEdge(
+    """The method to use when ordering \`Child\`."""
+    orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ChildrenEdge
+}
+
+"""All input for the \`updateOrganizationById\` mutation."""
+input UpdateOrganizationByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the \`Organization\` being updated.
+  """
+  organizationPatch: OrganizationPatch!
+  id: Int!
+}
+
+"""All input for the \`updateOrganization\` mutation."""
+input UpdateOrganizationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Organization\` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the \`Organization\` being updated.
+  """
+  organizationPatch: OrganizationPatch!
+}
+
+"""The output of our update \`Organization\` mutation."""
+type UpdateOrganizationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Organization\` that was updated by this mutation."""
+  organization: Organization
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`Organization\`. May be used by Relay 1."""
+  organizationEdge(
+    """The method to use when ordering \`Organization\`."""
+    orderBy: [OrganizationsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): OrganizationsEdge
+}
+
+"""All input for the \`updateOtherChildById\` mutation."""
+input UpdateOtherChildByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the \`OtherChild\` being updated.
+  """
+  otherChildPatch: OtherChildPatch!
+  id: Int!
+}
+
+"""All input for the \`updateOtherChild\` mutation."""
+input UpdateOtherChildInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`OtherChild\` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the \`OtherChild\` being updated.
+  """
+  otherChildPatch: OtherChildPatch!
+}
+
+"""The output of our update \`OtherChild\` mutation."""
+type UpdateOtherChildPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`OtherChild\` that was updated by this mutation."""
+  otherChild: OtherChild
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single \`Parent\` that is related to this \`OtherChild\`."""
+  parentByParentId: Parent
+
+  """An edge for our \`OtherChild\`. May be used by Relay 1."""
+  otherChildEdge(
+    """The method to use when ordering \`OtherChild\`."""
+    orderBy: [OtherChildrenOrderBy!] = [PRIMARY_KEY_ASC]
+  ): OtherChildrenEdge
+}
+
+"""All input for the \`updateParentById\` mutation."""
+input UpdateParentByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the \`Parent\` being updated.
+  """
+  parentPatch: ParentPatch!
+  id: Int!
+}
+
+"""All input for the \`updateParent\` mutation."""
+input UpdateParentInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Parent\` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the \`Parent\` being updated.
+  """
+  parentPatch: ParentPatch!
+}
+
+"""The output of our update \`Parent\` mutation."""
+type UpdateParentPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Parent\` that was updated by this mutation."""
+  parent: Parent
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`Parent\`. May be used by Relay 1."""
+  parentEdge(
+    """The method to use when ordering \`Parent\`."""
+    orderBy: [ParentsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ParentsEdge
+}
+
+`;
+
+exports[`status schema matches snapshot 1`] = `
+type Child implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  organizationId: Int!
+  parentId: Int!
+  name: String
+  isArchived: Boolean!
+  archivedAt: Datetime
+  isPublished: Boolean!
+  publishedAt: Datetime
+  status: String!
+
+  """Reads a single \`Organization\` that is related to this \`Child\`."""
+  organizationByOrganizationId: Organization
+
+  """Reads a single \`Parent\` that is related to this \`Child\`."""
+  parentByParentId: Parent
+}
+
+"""
+A condition to be used against \`Child\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input ChildCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`organizationId\` field."""
+  organizationId: Int
+
+  """Checks for equality with the object’s \`parentId\` field."""
+  parentId: Int
+
+  """Checks for equality with the object’s \`name\` field."""
+  name: String
+
+  """Checks for equality with the object’s \`isArchived\` field."""
+  isArchived: Boolean
+
+  """Checks for equality with the object’s \`archivedAt\` field."""
+  archivedAt: Datetime
+
+  """Checks for equality with the object’s \`isPublished\` field."""
+  isPublished: Boolean
+
+  """Checks for equality with the object’s \`publishedAt\` field."""
+  publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
+}
+
+"""An input for mutations affecting \`Child\`"""
+input ChildInput {
+  id: Int!
+  organizationId: Int!
+  parentId: Int!
+  name: String
+  isArchived: Boolean
+  archivedAt: Datetime
+  isPublished: Boolean
+  publishedAt: Datetime
+  status: String!
+}
+
+"""
+Represents an update to a \`Child\`. Fields that are set will be updated.
+"""
+input ChildPatch {
+  id: Int
+  organizationId: Int
+  parentId: Int
+  name: String
+  isArchived: Boolean
+  archivedAt: Datetime
+  isPublished: Boolean
+  publishedAt: Datetime
+  status: String
+}
+
+"""A connection to a list of \`Child\` values."""
+type ChildrenConnection {
+  """A list of \`Child\` objects."""
+  nodes: [Child]!
+
+  """
+  A list of edges which contains the \`Child\` and cursor to aid in pagination.
+  """
+  edges: [ChildrenEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Child\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Child\` edge in the connection."""
+type ChildrenEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Child\` at the end of the edge."""
+  node: Child
+}
+
+"""Methods to use when ordering \`Child\`."""
+enum ChildrenOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  ORGANIZATION_ID_ASC
+  ORGANIZATION_ID_DESC
+  PARENT_ID_ASC
+  PARENT_ID_DESC
+  NAME_ASC
+  NAME_DESC
+  IS_ARCHIVED_ASC
+  IS_ARCHIVED_DESC
+  ARCHIVED_AT_ASC
+  ARCHIVED_AT_DESC
+  IS_PUBLISHED_ASC
+  IS_PUBLISHED_DESC
+  PUBLISHED_AT_ASC
+  PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""All input for the create \`Child\` mutation."""
+input CreateChildInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`Child\` to be created by this mutation."""
+  child: ChildInput!
+}
+
+"""The output of our create \`Child\` mutation."""
+type CreateChildPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Child\` that was created by this mutation."""
+  child: Child
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single \`Organization\` that is related to this \`Child\`."""
+  organizationByOrganizationId: Organization
+
+  """Reads a single \`Parent\` that is related to this \`Child\`."""
+  parentByParentId: Parent
+
+  """An edge for our \`Child\`. May be used by Relay 1."""
+  childEdge(
+    """The method to use when ordering \`Child\`."""
+    orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ChildrenEdge
+}
+
+"""All input for the create \`Organization\` mutation."""
+input CreateOrganizationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`Organization\` to be created by this mutation."""
+  organization: OrganizationInput!
+}
+
+"""The output of our create \`Organization\` mutation."""
+type CreateOrganizationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Organization\` that was created by this mutation."""
+  organization: Organization
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`Organization\`. May be used by Relay 1."""
+  organizationEdge(
+    """The method to use when ordering \`Organization\`."""
+    orderBy: [OrganizationsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): OrganizationsEdge
+}
+
+"""All input for the create \`OtherChild\` mutation."""
+input CreateOtherChildInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`OtherChild\` to be created by this mutation."""
+  otherChild: OtherChildInput!
+}
+
+"""The output of our create \`OtherChild\` mutation."""
+type CreateOtherChildPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`OtherChild\` that was created by this mutation."""
+  otherChild: OtherChild
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single \`Parent\` that is related to this \`OtherChild\`."""
+  parentByParentId: Parent
+
+  """An edge for our \`OtherChild\`. May be used by Relay 1."""
+  otherChildEdge(
+    """The method to use when ordering \`OtherChild\`."""
+    orderBy: [OtherChildrenOrderBy!] = [PRIMARY_KEY_ASC]
+  ): OtherChildrenEdge
+}
+
+"""All input for the create \`Parent\` mutation."""
+input CreateParentInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`Parent\` to be created by this mutation."""
+  parent: ParentInput!
+}
+
+"""The output of our create \`Parent\` mutation."""
+type CreateParentPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Parent\` that was created by this mutation."""
+  parent: Parent
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`Parent\`. May be used by Relay 1."""
+  parentEdge(
+    """The method to use when ordering \`Parent\`."""
+    orderBy: [ParentsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ParentsEdge
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""
+A point in time as described by the [ISO
+8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+"""
+scalar Datetime
+
+"""All input for the \`deleteChildById\` mutation."""
+input DeleteChildByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the \`deleteChild\` mutation."""
+input DeleteChildInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Child\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete \`Child\` mutation."""
+type DeleteChildPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Child\` that was deleted by this mutation."""
+  child: Child
+  deletedChildId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single \`Organization\` that is related to this \`Child\`."""
+  organizationByOrganizationId: Organization
+
+  """Reads a single \`Parent\` that is related to this \`Child\`."""
+  parentByParentId: Parent
+
+  """An edge for our \`Child\`. May be used by Relay 1."""
+  childEdge(
+    """The method to use when ordering \`Child\`."""
+    orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ChildrenEdge
+}
+
+"""All input for the \`deleteOrganizationById\` mutation."""
+input DeleteOrganizationByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the \`deleteOrganization\` mutation."""
+input DeleteOrganizationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Organization\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete \`Organization\` mutation."""
+type DeleteOrganizationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Organization\` that was deleted by this mutation."""
+  organization: Organization
+  deletedOrganizationId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`Organization\`. May be used by Relay 1."""
+  organizationEdge(
+    """The method to use when ordering \`Organization\`."""
+    orderBy: [OrganizationsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): OrganizationsEdge
+}
+
+"""All input for the \`deleteOtherChildById\` mutation."""
+input DeleteOtherChildByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the \`deleteOtherChild\` mutation."""
+input DeleteOtherChildInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`OtherChild\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete \`OtherChild\` mutation."""
+type DeleteOtherChildPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`OtherChild\` that was deleted by this mutation."""
+  otherChild: OtherChild
+  deletedOtherChildId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Reads a single \`Parent\` that is related to this \`OtherChild\`."""
+  parentByParentId: Parent
+
+  """An edge for our \`OtherChild\`. May be used by Relay 1."""
+  otherChildEdge(
+    """The method to use when ordering \`OtherChild\`."""
+    orderBy: [OtherChildrenOrderBy!] = [PRIMARY_KEY_ASC]
+  ): OtherChildrenEdge
+}
+
+"""All input for the \`deleteParentById\` mutation."""
+input DeleteParentByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the \`deleteParent\` mutation."""
+input DeleteParentInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Parent\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete \`Parent\` mutation."""
+type DeleteParentPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Parent\` that was deleted by this mutation."""
+  parent: Parent
+  deletedParentId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`Parent\`. May be used by Relay 1."""
+  parentEdge(
+    """The method to use when ordering \`Parent\`."""
+    orderBy: [ParentsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ParentsEdge
+}
+
+"""
+Indicates whether statusArchived items should be included in the results or not.
+"""
+enum IncludeStatusArchivedOption {
+  """Exclude statusArchived items."""
+  NO
+
+  """Include statusArchived items."""
+  YES
+
+  """
+  Only include statusArchived items (i.e. exclude non-statusArchived items).
+  """
+  EXCLUSIVELY
+
+  """
+  If there is a parent GraphQL record and it is statusArchived then this is
+  equivalent to YES, in all other cases this is equivalent to NO.
+  """
+  INHERIT
+}
+
+"""
+The root mutation type which contains root level fields which mutate data.
+"""
+type Mutation {
+  """Creates a single \`Child\`."""
+  createChild(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateChildInput!
+  ): CreateChildPayload
+
+  """Creates a single \`Organization\`."""
+  createOrganization(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateOrganizationInput!
+  ): CreateOrganizationPayload
+
+  """Creates a single \`OtherChild\`."""
+  createOtherChild(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateOtherChildInput!
+  ): CreateOtherChildPayload
+
+  """Creates a single \`Parent\`."""
+  createParent(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateParentInput!
+  ): CreateParentPayload
+
+  """Updates a single \`Child\` using its globally unique id and a patch."""
+  updateChild(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateChildInput!
+  ): UpdateChildPayload
+
+  """Updates a single \`Child\` using a unique key and a patch."""
+  updateChildById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateChildByIdInput!
+  ): UpdateChildPayload
+
+  """
+  Updates a single \`Organization\` using its globally unique id and a patch.
+  """
+  updateOrganization(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateOrganizationInput!
+  ): UpdateOrganizationPayload
+
+  """Updates a single \`Organization\` using a unique key and a patch."""
+  updateOrganizationById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateOrganizationByIdInput!
+  ): UpdateOrganizationPayload
+
+  """
+  Updates a single \`OtherChild\` using its globally unique id and a patch.
+  """
+  updateOtherChild(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateOtherChildInput!
+  ): UpdateOtherChildPayload
+
+  """Updates a single \`OtherChild\` using a unique key and a patch."""
+  updateOtherChildById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateOtherChildByIdInput!
+  ): UpdateOtherChildPayload
+
+  """Updates a single \`Parent\` using its globally unique id and a patch."""
+  updateParent(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateParentInput!
+  ): UpdateParentPayload
+
+  """Updates a single \`Parent\` using a unique key and a patch."""
+  updateParentById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateParentByIdInput!
+  ): UpdateParentPayload
+
+  """Deletes a single \`Child\` using its globally unique id."""
+  deleteChild(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteChildInput!
+  ): DeleteChildPayload
+
+  """Deletes a single \`Child\` using a unique key."""
+  deleteChildById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteChildByIdInput!
+  ): DeleteChildPayload
+
+  """Deletes a single \`Organization\` using its globally unique id."""
+  deleteOrganization(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteOrganizationInput!
+  ): DeleteOrganizationPayload
+
+  """Deletes a single \`Organization\` using a unique key."""
+  deleteOrganizationById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteOrganizationByIdInput!
+  ): DeleteOrganizationPayload
+
+  """Deletes a single \`OtherChild\` using its globally unique id."""
+  deleteOtherChild(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteOtherChildInput!
+  ): DeleteOtherChildPayload
+
+  """Deletes a single \`OtherChild\` using a unique key."""
+  deleteOtherChildById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteOtherChildByIdInput!
+  ): DeleteOtherChildPayload
+
+  """Deletes a single \`Parent\` using its globally unique id."""
+  deleteParent(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteParentInput!
+  ): DeleteParentPayload
+
+  """Deletes a single \`Parent\` using a unique key."""
+  deleteParentById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteParentByIdInput!
+  ): DeleteParentPayload
+}
+
+"""An object with a globally unique \`ID\`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+type Organization implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  name: String
+  isArchived: Boolean!
+  archivedAt: Datetime
+  isPublished: Boolean!
+  publishedAt: Datetime
+  status: String!
+
+  """Reads and enables pagination through a set of \`Child\`."""
+  childrenByOrganizationId(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering \`Child\`."""
+    orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChildCondition
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeStatusArchived: IncludeStatusArchivedOption = INHERIT
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeWhenOrganizationByOrganizationIdStatusArchived: IncludeStatusArchivedOption = INHERIT
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeWhenParentByParentIdStatusArchived: IncludeStatusArchivedOption = INHERIT
+  ): ChildrenConnection!
+
+  """Reads and enables pagination through a set of \`Child\`."""
+  childrenByOrganizationIdList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """The method to use when ordering \`Child\`."""
+    orderBy: [ChildrenOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChildCondition
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeStatusArchived: IncludeStatusArchivedOption = INHERIT
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeWhenOrganizationByOrganizationIdStatusArchived: IncludeStatusArchivedOption = INHERIT
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeWhenParentByParentIdStatusArchived: IncludeStatusArchivedOption = INHERIT
+  ): [Child!]!
+}
+
+"""
+A condition to be used against \`Organization\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input OrganizationCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`name\` field."""
+  name: String
+
+  """Checks for equality with the object’s \`isArchived\` field."""
+  isArchived: Boolean
+
+  """Checks for equality with the object’s \`archivedAt\` field."""
+  archivedAt: Datetime
+
+  """Checks for equality with the object’s \`isPublished\` field."""
+  isPublished: Boolean
+
+  """Checks for equality with the object’s \`publishedAt\` field."""
+  publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
+}
+
+"""An input for mutations affecting \`Organization\`"""
+input OrganizationInput {
+  id: Int!
+  name: String
+  isArchived: Boolean
+  archivedAt: Datetime
+  isPublished: Boolean
+  publishedAt: Datetime
+  status: String!
+}
+
+"""
+Represents an update to a \`Organization\`. Fields that are set will be updated.
+"""
+input OrganizationPatch {
+  id: Int
+  name: String
+  isArchived: Boolean
+  archivedAt: Datetime
+  isPublished: Boolean
+  publishedAt: Datetime
+  status: String
+}
+
+"""A connection to a list of \`Organization\` values."""
+type OrganizationsConnection {
+  """A list of \`Organization\` objects."""
+  nodes: [Organization]!
+
+  """
+  A list of edges which contains the \`Organization\` and cursor to aid in pagination.
+  """
+  edges: [OrganizationsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Organization\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Organization\` edge in the connection."""
+type OrganizationsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Organization\` at the end of the edge."""
+  node: Organization
+}
+
+"""Methods to use when ordering \`Organization\`."""
+enum OrganizationsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  IS_ARCHIVED_ASC
+  IS_ARCHIVED_DESC
+  ARCHIVED_AT_ASC
+  ARCHIVED_AT_DESC
+  IS_PUBLISHED_ASC
+  IS_PUBLISHED_DESC
+  PUBLISHED_AT_ASC
+  PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+type OtherChild implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  parentId: Int!
+  title: String
+
+  """Reads a single \`Parent\` that is related to this \`OtherChild\`."""
+  parentByParentId: Parent
+}
+
+"""
+A condition to be used against \`OtherChild\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input OtherChildCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`parentId\` field."""
+  parentId: Int
+
+  """Checks for equality with the object’s \`title\` field."""
+  title: String
+}
+
+"""An input for mutations affecting \`OtherChild\`"""
+input OtherChildInput {
+  id: Int!
+  parentId: Int!
+  title: String
+}
+
+"""
+Represents an update to a \`OtherChild\`. Fields that are set will be updated.
+"""
+input OtherChildPatch {
+  id: Int
+  parentId: Int
+  title: String
+}
+
+"""A connection to a list of \`OtherChild\` values."""
+type OtherChildrenConnection {
+  """A list of \`OtherChild\` objects."""
+  nodes: [OtherChild]!
+
+  """
+  A list of edges which contains the \`OtherChild\` and cursor to aid in pagination.
+  """
+  edges: [OtherChildrenEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`OtherChild\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`OtherChild\` edge in the connection."""
+type OtherChildrenEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`OtherChild\` at the end of the edge."""
+  node: OtherChild
+}
+
+"""Methods to use when ordering \`OtherChild\`."""
+enum OtherChildrenOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  PARENT_ID_ASC
+  PARENT_ID_DESC
+  TITLE_ASC
+  TITLE_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+}
+
+type Parent implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  name: String
+  isArchived: Boolean!
+  archivedAt: Datetime
+  isPublished: Boolean!
+  publishedAt: Datetime
+  status: String!
+
+  """Reads and enables pagination through a set of \`Child\`."""
+  childrenByParentId(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering \`Child\`."""
+    orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChildCondition
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeStatusArchived: IncludeStatusArchivedOption = INHERIT
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeWhenOrganizationByOrganizationIdStatusArchived: IncludeStatusArchivedOption = INHERIT
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeWhenParentByParentIdStatusArchived: IncludeStatusArchivedOption = INHERIT
+  ): ChildrenConnection!
+
+  """Reads and enables pagination through a set of \`Child\`."""
+  childrenByParentIdList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """The method to use when ordering \`Child\`."""
+    orderBy: [ChildrenOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChildCondition
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeStatusArchived: IncludeStatusArchivedOption = INHERIT
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeWhenOrganizationByOrganizationIdStatusArchived: IncludeStatusArchivedOption = INHERIT
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeWhenParentByParentIdStatusArchived: IncludeStatusArchivedOption = INHERIT
+  ): [Child!]!
+
+  """Reads and enables pagination through a set of \`OtherChild\`."""
+  otherChildrenByParentId(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering \`OtherChild\`."""
+    orderBy: [OtherChildrenOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: OtherChildCondition
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeWhenParentByParentIdStatusArchived: IncludeStatusArchivedOption = INHERIT
+  ): OtherChildrenConnection!
+
+  """Reads and enables pagination through a set of \`OtherChild\`."""
+  otherChildrenByParentIdList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """The method to use when ordering \`OtherChild\`."""
+    orderBy: [OtherChildrenOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: OtherChildCondition
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeWhenParentByParentIdStatusArchived: IncludeStatusArchivedOption = INHERIT
+  ): [OtherChild!]!
+}
+
+"""
+A condition to be used against \`Parent\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input ParentCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`name\` field."""
+  name: String
+
+  """Checks for equality with the object’s \`isArchived\` field."""
+  isArchived: Boolean
+
+  """Checks for equality with the object’s \`archivedAt\` field."""
+  archivedAt: Datetime
+
+  """Checks for equality with the object’s \`isPublished\` field."""
+  isPublished: Boolean
+
+  """Checks for equality with the object’s \`publishedAt\` field."""
+  publishedAt: Datetime
+
+  """Checks for equality with the object’s \`status\` field."""
+  status: String
+}
+
+"""An input for mutations affecting \`Parent\`"""
+input ParentInput {
+  id: Int!
+  name: String
+  isArchived: Boolean
+  archivedAt: Datetime
+  isPublished: Boolean
+  publishedAt: Datetime
+  status: String!
+}
+
+"""
+Represents an update to a \`Parent\`. Fields that are set will be updated.
+"""
+input ParentPatch {
+  id: Int
+  name: String
+  isArchived: Boolean
+  archivedAt: Datetime
+  isPublished: Boolean
+  publishedAt: Datetime
+  status: String
+}
+
+"""A connection to a list of \`Parent\` values."""
+type ParentsConnection {
+  """A list of \`Parent\` objects."""
+  nodes: [Parent]!
+
+  """
+  A list of edges which contains the \`Parent\` and cursor to aid in pagination.
+  """
+  edges: [ParentsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Parent\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Parent\` edge in the connection."""
+type ParentsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Parent\` at the end of the edge."""
+  node: Parent
+}
+
+"""Methods to use when ordering \`Parent\`."""
+enum ParentsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  IS_ARCHIVED_ASC
+  IS_ARCHIVED_DESC
+  ARCHIVED_AT_ASC
+  ARCHIVED_AT_DESC
+  IS_PUBLISHED_ASC
+  IS_PUBLISHED_DESC
+  PUBLISHED_AT_ASC
+  PUBLISHED_AT_DESC
+  STATUS_ASC
+  STATUS_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""The root query type which gives access points into the data universe."""
+type Query implements Node {
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
+
+  """Fetches an object given its globally unique \`ID\`."""
+  node(
+    """The globally unique \`ID\`."""
+    nodeId: ID!
+  ): Node
+
+  """Reads and enables pagination through a set of \`Child\`."""
+  allChildren(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering \`Child\`."""
+    orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChildCondition
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeStatusArchived: IncludeStatusArchivedOption = NO
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeWhenOrganizationByOrganizationIdStatusArchived: IncludeStatusArchivedOption = NO
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeWhenParentByParentIdStatusArchived: IncludeStatusArchivedOption = NO
+  ): ChildrenConnection
+
+  """Reads a set of \`Child\`."""
+  allChildrenList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """The method to use when ordering \`Child\`."""
+    orderBy: [ChildrenOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChildCondition
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeStatusArchived: IncludeStatusArchivedOption = NO
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeWhenOrganizationByOrganizationIdStatusArchived: IncludeStatusArchivedOption = NO
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeWhenParentByParentIdStatusArchived: IncludeStatusArchivedOption = NO
+  ): [Child!]
+
+  """Reads and enables pagination through a set of \`Organization\`."""
+  allOrganizations(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering \`Organization\`."""
+    orderBy: [OrganizationsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: OrganizationCondition
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeStatusArchived: IncludeStatusArchivedOption = NO
+  ): OrganizationsConnection
+
+  """Reads a set of \`Organization\`."""
+  allOrganizationsList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """The method to use when ordering \`Organization\`."""
+    orderBy: [OrganizationsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: OrganizationCondition
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeStatusArchived: IncludeStatusArchivedOption = NO
+  ): [Organization!]
+
+  """Reads and enables pagination through a set of \`OtherChild\`."""
+  allOtherChildren(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering \`OtherChild\`."""
+    orderBy: [OtherChildrenOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: OtherChildCondition
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeWhenParentByParentIdStatusArchived: IncludeStatusArchivedOption = NO
+  ): OtherChildrenConnection
+
+  """Reads a set of \`OtherChild\`."""
+  allOtherChildrenList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """The method to use when ordering \`OtherChild\`."""
+    orderBy: [OtherChildrenOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: OtherChildCondition
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeWhenParentByParentIdStatusArchived: IncludeStatusArchivedOption = NO
+  ): [OtherChild!]
+
+  """Reads and enables pagination through a set of \`Parent\`."""
+  allParents(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering \`Parent\`."""
+    orderBy: [ParentsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ParentCondition
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeStatusArchived: IncludeStatusArchivedOption = NO
+  ): ParentsConnection
+
+  """Reads a set of \`Parent\`."""
+  allParentsList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """The method to use when ordering \`Parent\`."""
+    orderBy: [ParentsOrderBy!]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ParentCondition
+
+    """
+    Indicates whether statusArchived items should be included in the results or not.
+    """
+    includeStatusArchived: IncludeStatusArchivedOption = NO
   ): [Parent!]
   childById(id: Int!): Child
   organizationById(id: Int!): Organization

--- a/__tests__/main.js
+++ b/__tests__/main.js
@@ -126,13 +126,13 @@ describe.each([
     "status",
     "statusArchived",
     {
-      pgStatusArchivedAppliesTo: [
+      pgStatusArchivedTables: [
         "omit_archived.organizations",
         "omit_archived.parents",
         "omit_archived.children",
       ],
       pgStatusArchivedExpression: (sql, tableAlias) =>
-        sql.fragment`${tableAlias}.status != 'archived'`,
+        sql.fragment`${tableAlias}.status = 'archived'`,
       pgStatusArchivedRelations: true,
     },
   ],

--- a/__tests__/main.js
+++ b/__tests__/main.js
@@ -26,7 +26,8 @@ create table omit_archived.organizations (
   is_archived boolean not null default false,
   archived_at timestamptz default null,
   is_published boolean not null default true,
-  published_at timestamptz default now()
+  published_at timestamptz default now(),
+  status text not null
 );
 create table omit_archived.parents (
   id int primary key,
@@ -34,7 +35,8 @@ create table omit_archived.parents (
   is_archived boolean not null default false,
   archived_at timestamptz default null,
   is_published boolean not null default true,
-  published_at timestamptz default now()
+  published_at timestamptz default now(),
+  status text not null
 );
 create table omit_archived.children (
   id int primary key,
@@ -45,6 +47,7 @@ create table omit_archived.children (
   archived_at timestamptz default null,
   is_published boolean not null default true,
   published_at timestamptz default now(),
+  status text not null,
   constraint fk_children_parents foreign key (parent_id) references omit_archived.parents
 );
 create index on omit_archived.children(parent_id);
@@ -53,15 +56,15 @@ create table omit_archived.other_children (
   parent_id int not null references omit_archived.parents,
   title text
 );
-insert into omit_archived.organizations (id, name, is_archived, archived_at, is_published, published_at)
-  values (3, 'GoodOrganization', false, null, true, now()), (4, 'BadOrganization', true, now(), false, null);
-insert into omit_archived.parents (id, name, is_archived, archived_at, is_published, published_at)
-  values (1, 'First', false, null, true, now()), (2, 'Second', true, now(), false, null);
-insert into omit_archived.children (id, organization_id, parent_id, name, is_archived, archived_at, is_published, published_at) values
-  (1001, 3, 1, 'First child 1', false, null, true, now()),
-  (1002, 3, 1, 'First child 2', true, now(), false, null),
-  (2001, 3, 2, 'Second child 1', false, null, true, now()),
-  (2002, 3, 2, 'Second child 2', true, now(), false, null);
+insert into omit_archived.organizations (id, name, is_archived, archived_at, is_published, published_at, status)
+  values (3, 'GoodOrganization', false, null, true, now(), 'published'), (4, 'BadOrganization', true, now(), false, null, 'archived');
+insert into omit_archived.parents (id, name, is_archived, archived_at, is_published, published_at, status)
+  values (1, 'First', false, null, true, now(), 'published'), (2, 'Second', true, now(), false, null, 'archived');
+insert into omit_archived.children (id, organization_id, parent_id, name, is_archived, archived_at, is_published, published_at, status) values
+  (1001, 3, 1, 'First child 1', false, null, true, now(), 'published'),
+  (1002, 3, 1, 'First child 2', true, now(), false, null, 'archived'),
+  (2001, 3, 2, 'Second child 1', false, null, true, now(), 'published'),
+  (2002, 3, 2, 'Second child 2', true, now(), false, null, 'archived');
 insert into omit_archived.other_children (id, parent_id, title) values
   (101, 1, 'First other child 1'),
   (102, 1, 'First other child 2'),
@@ -117,6 +120,20 @@ describe.each([
       pgDraftColumnName: "published_at",
       pgDraftColumnImpliesVisible: true,
       pgDraftRelations: true,
+    },
+  ],
+  [
+    "status",
+    "statusArchived",
+    {
+      pgStatusArchivedAppliesTo: [
+        "omit_archived.organizations",
+        "omit_archived.parents",
+        "omit_archived.children",
+      ],
+      pgStatusArchivedExpression: (sql, tableAlias) =>
+        sql.fragment`${tableAlias}.status != 'archived'`,
+      pgStatusArchivedRelations: true,
     },
   ],
 ])("%s", (_columnName, keyword, graphileBuildOptions, config = {}) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,11 +42,41 @@ const makeUtils = (
       // `published_at`; false for `is_archived` or `archived_at`).
       [`pg${Keyword}ColumnImpliesVisible`]: invert = false,
       [`pg${Keyword}Relations`]: applyToRelations = false,
+      [`pg${Keyword}Expression`]: expression = null,
+      [`pg${Keyword}Tables`]: rawTables = null,
     },
   } = build;
   const sql = build.pgSql as typeof import("pg-sql2");
   const introspectionResultsByKind = build.pgIntrospectionResultsByKind as PgIntrospectionResultsByKind;
   const OptionType = getTypeByName(`Include${Keyword}Option`);
+
+  if (expression && build.options[`pg${Keyword}ColumnName`]) {
+    throw new Error(
+      `'pg${Keyword}Expression' cannot be combined with 'pg${Keyword}ColumnName'`,
+    );
+  }
+  if (expression && build.options[`pg${Keyword}ColumnImpliesVisible`]) {
+    throw new Error(
+      `'pg${Keyword}Expression' cannot be combined with 'pg${Keyword}ColumnImpliesVisible'`,
+    );
+  }
+  if (expression && !build.options[`pg${Keyword}Tables`]) {
+    throw new Error(
+      `'pg${Keyword}Expression' requires 'pg${Keyword}Tables' to be set to a list of the tables to which this expression can apply.`,
+    );
+  }
+
+  const tables = rawTables
+    ? (rawTables as string[]).map((t) => {
+        const [schemaOrTable, tableOnly, ...rest] = t.split(".");
+        if (rest.length) {
+          throw new Error("Could not parse ${t} into schema + table.");
+        }
+        return tableOnly
+          ? [schemaOrTable, tableOnly]
+          : ["public", schemaOrTable];
+      })
+    : null;
 
   const getRelevantColumn = (tableToCheck: PgClass) =>
     tableToCheck
@@ -56,6 +86,14 @@ const makeUtils = (
         )
       : null;
 
+  const _tableIsAllowed = (table: PgClass | null | undefined) =>
+    table != null &&
+    (tables == null ||
+      tables.some((t) => table.namespaceName === t[0] && table.name === t[1]));
+
+  const appliesToTable = (table: PgClass) =>
+    _tableIsAllowed(table) && (expression || getRelevantColumn(table));
+
   if (relevantRelation) {
     if (!applyToRelations && !relevantRelation.tags[`${keyword}Relation`]) {
       return null;
@@ -63,21 +101,21 @@ const makeUtils = (
     if (
       !relevantRelation.foreignClass ||
       relevantRelation.classId !== table.id ||
-      !getRelevantColumn(relevantRelation.foreignClass)
+      !appliesToTable(relevantRelation.foreignClass)
     ) {
       return null;
     }
   }
 
-  const relevantColumn = relevantRelation
-    ? relevantRelation.foreignClass
-      ? getRelevantColumn(relevantRelation.foreignClass)
-      : null
-    : getRelevantColumn(table);
+  const relevantClass = relevantRelation
+    ? (relevantRelation.foreignClass as PgClass | never)
+    : table;
 
-  if (!relevantColumn) {
+  if (!relevantClass) {
     return null;
   }
+
+  const relevantColumn = getRelevantColumn(relevantClass);
 
   const argumentName = inflection[`include${Keyword}Argument`](
     table,
@@ -85,23 +123,11 @@ const makeUtils = (
   );
 
   const parentTableRelevantColumn = getRelevantColumn(parentTable);
-  const capableOfInherit = allowInherit && !!parentTableRelevantColumn;
-  const pgRelevantColumnIsBoolean = relevantColumn.type.category === "B";
-  const pgParentRelevantColumnIsBoolean =
+  const capableOfInherit = allowInherit && appliesToTable(parentTable);
+  const pgRelevantColumnIsBoolean = relevantColumn?.type.category === "B";
+  const pgParentTableRelevantColumnIsBoolean =
     parentTableRelevantColumn &&
     parentTableRelevantColumn.type.category === "B";
-
-  const columnDetails = {
-    isBoolean: pgRelevantColumnIsBoolean,
-    name: relevantColumn.name,
-  };
-  const parentColumnDetails = parentTableRelevantColumn
-    ? {
-        isBoolean: pgParentRelevantColumnIsBoolean,
-        canInherit: capableOfInherit,
-        name: parentTableRelevantColumn.name,
-      }
-    : null;
 
   const booleanVisibleFragment = invert
     ? sql.fragment`true`
@@ -119,34 +145,70 @@ const makeUtils = (
     ? sql.fragment`null`
     : sql.fragment`not null`;
 
-  const [visibleFragment, invisibleFragment] = columnDetails.isBoolean
-    ? [booleanVisibleFragment, booleanInvisibleFragment]
-    : [nullableVisibleFragment, nullableInvisibleFragment];
+  const rawLocalDetails = expression
+    ? appliesToTable(relevantClass)
+      ? {
+          expression: expression,
+          visibleFragment: booleanVisibleFragment,
+          invisibleFragment: booleanInvisibleFragment,
+        }
+      : null
+    : relevantColumn
+    ? {
+        expression: (_sql: typeof sql, tableAlias: SQL) =>
+          sql.fragment`${tableAlias}.${sql.identifier(relevantColumn.name)}`,
+        visibleFragment: pgRelevantColumnIsBoolean
+          ? booleanVisibleFragment
+          : nullableVisibleFragment,
+        invisibleFragment: pgRelevantColumnIsBoolean
+          ? booleanInvisibleFragment
+          : nullableInvisibleFragment,
+      }
+    : null;
 
-  const [_parentVisibleFragment, parentInvisibleFragment] =
-    parentColumnDetails && parentColumnDetails.isBoolean
-      ? [booleanVisibleFragment, booleanInvisibleFragment]
-      : [nullableVisibleFragment, nullableInvisibleFragment];
+  if (!rawLocalDetails) {
+    return null;
+  }
+  const localDetails = rawLocalDetails;
+
+  const parentDetails = appliesToTable(parentTable)
+    ? expression
+      ? {
+          expression: expression,
+          visibleFragment: booleanVisibleFragment,
+          invisibleFragment: booleanInvisibleFragment,
+        }
+      : parentTableRelevantColumn
+      ? {
+          expression: (_sql: typeof sql, tableAlias: SQL) =>
+            sql.fragment`${tableAlias}.${sql.identifier(
+              parentTableRelevantColumn.name,
+            )}`,
+          visibleFragment: pgParentTableRelevantColumnIsBoolean
+            ? booleanVisibleFragment
+            : nullableVisibleFragment,
+          invisibleFragment: pgParentTableRelevantColumnIsBoolean
+            ? booleanInvisibleFragment
+            : nullableInvisibleFragment,
+        }
+      : null
+    : null;
 
   function addWhereClause(queryBuilder: QueryBuilder, fieldArgs: any) {
-    // TypeScript hack
-    if (!relevantColumn) {
-      return;
-    }
     const { [argumentName]: relevantSetting } = fieldArgs;
     let fragment: SQL | null = null;
 
     const myAlias =
-      relevantColumn.class !== table
+      relevantClass !== table
         ? sql.identifier(Symbol("me"))
         : queryBuilder.getTableAlias();
     if (
       relevantRelation &&
-      relevantColumn.class !== table &&
+      relevantClass !== table &&
       relevantRelation.foreignClass === parentTable &&
       capableOfInherit &&
       queryBuilder.parentQueryBuilder &&
-      parentColumnDetails &&
+      parentDetails &&
       ["INHERIT", "YES"].includes(relevantSetting)
     ) {
       // In this case the work is already done by the parent record and it
@@ -159,29 +221,31 @@ const makeUtils = (
       capableOfInherit &&
       relevantSetting === "INHERIT" &&
       queryBuilder.parentQueryBuilder &&
-      parentColumnDetails
+      parentDetails
     ) {
       const sqlParentTableAlias = queryBuilder.parentQueryBuilder.getTableAlias();
-      fragment = sql.fragment`(${sqlParentTableAlias}.${sql.identifier(
-        parentColumnDetails.name,
-      )} is ${parentInvisibleFragment} or ${myAlias}.${sql.identifier(
-        columnDetails.name,
-      )} is ${visibleFragment})`;
+      fragment = sql.fragment`(${parentDetails.expression(
+        sql,
+        sqlParentTableAlias,
+      )} is ${parentDetails.invisibleFragment} or ${localDetails.expression(
+        sql,
+        myAlias,
+      )} is ${localDetails.visibleFragment})`;
     } else if (
       relevantSetting === "NO" ||
       // INHERIT is equivalent to NO if there's no valid parent
       relevantSetting === "INHERIT"
     ) {
-      fragment = sql.fragment`${myAlias}.${sql.identifier(
-        columnDetails.name,
-      )} is ${visibleFragment}`;
+      fragment = sql.fragment`${localDetails.expression(sql, myAlias)} is ${
+        localDetails.visibleFragment
+      }`;
     } else if (relevantSetting === "EXCLUSIVELY") {
-      fragment = sql.fragment`${myAlias}.${sql.identifier(
-        columnDetails.name,
-      )} is ${invisibleFragment}`;
+      fragment = sql.fragment`${localDetails.expression(sql, myAlias)} is ${
+        localDetails.invisibleFragment
+      }`;
     }
     if (fragment) {
-      if (relevantRelation && relevantColumn.class !== table) {
+      if (relevantRelation && relevantClass !== table) {
         const localAlias = queryBuilder.getTableAlias();
         const relationConditions = relevantRelation.keyAttributes.map(
           (attr, i) => {
@@ -192,8 +256,8 @@ const makeUtils = (
           },
         );
         const subquery = sql.fragment`exists (select 1 from ${sql.identifier(
-          relevantColumn.class.namespaceName,
-          relevantColumn.class.name,
+          relevantClass.namespaceName,
+          relevantClass.name,
         )} as ${myAlias} where (${sql.join(
           relationConditions,
           ") and (",

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,8 @@ const makeUtils = (
   const rawLocalDetails = expression
     ? appliesToTable(relevantClass)
       ? {
-          expression: expression,
+          expression: (_sql: typeof sql, tableAlias: SQL) =>
+            sql.fragment`(${expression(sql, tableAlias)})`,
           visibleFragment: booleanVisibleFragment,
           invisibleFragment: booleanInvisibleFragment,
         }
@@ -174,7 +175,8 @@ const makeUtils = (
   const parentDetails = appliesToTable(parentTable)
     ? expression
       ? {
-          expression: expression,
+          expression: (_sql: typeof sql, tableAlias: SQL) =>
+            sql.fragment`(${expression(sql, tableAlias)})`,
           visibleFragment: booleanVisibleFragment,
           invisibleFragment: booleanInvisibleFragment,
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,7 @@ const makeUtils = (
   const parentTableRelevantColumn = getRelevantColumn(parentTable);
   const capableOfInherit = allowInherit && appliesToTable(parentTable);
   const pgRelevantColumnIsBoolean = relevantColumn?.type.category === "B";
-  const pgParentTableRelevantColumnIsBoolean =
+  const pgParentRelevantColumnIsBoolean =
     parentTableRelevantColumn &&
     parentTableRelevantColumn.type.category === "B";
 
@@ -186,10 +186,10 @@ const makeUtils = (
             sql.fragment`${tableAlias}.${sql.identifier(
               parentTableRelevantColumn.name,
             )}`,
-          visibleFragment: pgParentTableRelevantColumnIsBoolean
+          visibleFragment: pgParentRelevantColumnIsBoolean
             ? booleanVisibleFragment
             : nullableVisibleFragment,
-          invisibleFragment: pgParentTableRelevantColumnIsBoolean
+          invisibleFragment: pgParentRelevantColumnIsBoolean
             ? booleanInvisibleFragment
             : nullableInvisibleFragment,
         }


### PR DESCRIPTION
Fixes #25

If a boolean or nullable column is not sufficient for your needs then this PR allows you to use an expression instead. This allows you to write queries such as `my_table.status = 'archived'` or `my_table.archived_at is not null or my_table.deleted_at is not null or my_table.published_at is null` or even `my_computed_column(my_table) is true` (but be careful with that one; performance would likely be poor!).

To use this, instead of setting `pgArchivedColumnName` you can specify both:

- `pgArchivedExpression` (or `pg<Keyword>Expression`): a function that accepts `sql` and `tableAlias` and returns a [pg-sql2 fragment](https://github.com/graphile/graphile-engine/tree/9d6c29e3505844ca64020fb6850093a7678a0fa4/packages/pg-sql2#sqlquery) that should resolve to a boolean indicating that the row should be omitted
- `pgArchivedTables` (or `pg<Keyword>Tables`): an array of tables that this expression applies to (since we can't determine this automatically)

```ts
app.use(
  postgraphile(process.env.DATABASE_URL, "app_public", {
    appendPlugins: [customPgOmitArchived("archived")],
    graphileBuildOptions: {
      /* 👇👇👇 */
      // What tables does the expression apply to?
      pgArchivedTables: ["my_schema.my_table"],

      // SQL expression that returns true if the row should be omitted
      pgArchivedExpression: (sql, tableAlias) =>
        sql.fragment`${tableAlias}.status = 'archived'`,
      /* ☝️☝️☝️ */
    },
  }),
);
```

