### PR TITLE
Add graphile-export support

### DIFF
--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -201,18 +201,20 @@ comment on constraint fk_children_parents on omit_archived.children is E'@archiv
     /** @type {(query: string, expected: any, checker?: (arg: import("graphql").ExecutionResult) => void) => () => Promise<void>} */
     function check(query, expected, checker) {
       return async () => {
-        const result = /** @type {import('graphql').ExecutionResult} */ (await grafast(
-          {
-            schema,
-            source: query,
-            rootValue: null,
-            contextValue: {},
-            variableValues: {},
-            operationName: null,
-          },
-          resolvedPreset,
-          {},
-        ));
+        const result = /** @type {import('graphql').ExecutionResult} */ (
+          await grafast(
+            {
+              schema,
+              source: query,
+              rootValue: null,
+              contextValue: {},
+              variableValues: {},
+              operationName: null,
+            },
+            resolvedPreset,
+            {},
+          )
+        );
         if (checker) {
           checker(result);
         } else {

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -201,20 +201,18 @@ comment on constraint fk_children_parents on omit_archived.children is E'@archiv
     /** @type {(query: string, expected: any, checker?: (arg: import("graphql").ExecutionResult) => void) => () => Promise<void>} */
     function check(query, expected, checker) {
       return async () => {
-        const result = /** @type {import('graphql').ExecutionResult} */ (
-          await grafast(
-            {
-              schema,
-              source: query,
-              rootValue: null,
-              contextValue: {},
-              variableValues: {},
-              operationName: null,
-            },
-            resolvedPreset,
-            {},
-          )
-        );
+        const result = /** @type {import('graphql').ExecutionResult} */ (await grafast(
+          {
+            schema,
+            source: query,
+            rootValue: null,
+            contextValue: {},
+            variableValues: {},
+            operationName: null,
+          },
+          resolvedPreset,
+          {},
+        ));
         if (checker) {
           checker(result);
         } else {
@@ -867,6 +865,7 @@ comment on constraint fk_children_parents on omit_archived.children is E'@archiv
     });
 
     if (pgArchivedRelations) {
+      // eslint-disable-next-line jest/valid-title
       describe(pgRelationsAttr, () => {
         it(
           "Defaults to omitting other_children where parent is archived",


### PR DESCRIPTION
> There's a bug with pg-omit-archived when used with graphile-export - I'm getting addWhereClause is not defined when I query a connection that pg-omit-archived would affect
> \- [Discord mesage](https://discord.com/channels/489127045289476126/498852330754801666/1209012182550061077)

This pr adds `graphile-export` support to `pg-omit-archived`.

This has been tested using `graphile-export` and verified running on a lambda. See below image

<img width="732" alt="Screenshot 2024-02-21 at 10 32 55 am" src="https://github.com/graphile-contrib/pg-omit-archived/assets/1670700/8afaa883-fa38-46f6-9baf-a6eb2028147a">
