### PR TITLE
Add lambda to dependency array for exportable `addwhereClause` function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -340,6 +340,7 @@ const makeUtils = (
         relevantRelation,
         sql,
         table,
+        lambda
       ) =>
       ($parent: ExecutableStep, $select: PgSelectStep, fieldArgs: FieldArg) => {
         const $parentSelectSingle =
@@ -450,6 +451,7 @@ const makeUtils = (
       relevantRelation,
       sql,
       table,
+      lambda
     ],
   );
 


### PR DESCRIPTION
Fixes #51 

Suspecting this occurred because the graphile-export logic (in particular the upgrader linter) changed. Thought about bumping the packages, but wasn't sure if there were any other breaking changes, so made the PR as small as possible.

All that was needed was to include `lambda` in the dependency array.

